### PR TITLE
Mobile horizontal scroll

### DIFF
--- a/docs/styles.css
+++ b/docs/styles.css
@@ -239,6 +239,8 @@ h1 {
 
 .code-block code {
     flex: 1;
+    min-width: 0;
+    overflow-wrap: anywhere;
 }
 
 .copy-btn {
@@ -453,6 +455,11 @@ footer a:hover {
     }
     
     .example-grid {
+        grid-template-columns: 1fr;
+    }
+
+    .completion-grid,
+    .why-grid {
         grid-template-columns: 1fr;
     }
 }


### PR DESCRIPTION
Fix mobile horizontal overflow by adjusting grid columns and code block wrapping.

Fixed fixed `minmax(...)` grid widths inside padded sections and wide code snippets that were forcing the layout wider than the viewport on small screens.

---
<p><a href="https://cursor.com/agents/bc-e20e70bd-6664-4f6d-b038-eab64165ff7f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e20e70bd-6664-4f6d-b038-eab64165ff7f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

