### PR TITLE
Add support for targeting existing PRs with Cursor agent

### DIFF
--- a/commands/create-issue.ts
+++ b/commands/create-issue.ts
@@ -15,6 +15,7 @@
  *   --template PATH   Path to issue template (default: look in .github/issue_template.md, etc.)
  *   --no-template    Skip template, use only body
  *   --no-comment     Do not add the agent instruction comment
+ *   --pr NUMBER      Update an existing PR branch instead of creating a new one (Cursor API only)
  *   --dry-run        Show what would be created without creating
  *
  * Template lookup (first found): .github/issue_template.md,
@@ -32,7 +33,7 @@ import { initializeRuntime } from "../lib/runtime-init.js";
 import { REPO_PATTERN, validateRepo, validateAgent } from "../lib/gh.js";
 import { getOriginRepo } from "../lib/utils.js";
 import { loadConfig } from "../lib/config.js";
-import { launchAgentForRepository } from "../lib/cursor-api.js";
+import { launchAgentForPrUrl, launchAgentForRepository } from "../lib/cursor-api.js";
 
 initializeRuntime();
 
@@ -201,11 +202,24 @@ async function sendInstructionViaCursorApi(
   agent: string,
   comment: string,
   cursorApiKey: string,
-  dryRun: boolean
+  dryRun: boolean,
+  targetPr: number | null
 ): Promise<void> {
   const issueUrl = `https://github.com/${repo}/issues/${issueNumber}`;
   const instruction = stripAgentMention(comment, agent);
   const prompt = `${instruction}\n\nIssue: ${issueUrl}`;
+
+  if (targetPr) {
+    const prUrl = `https://github.com/${repo}/pull/${targetPr}`;
+    if (dryRun) {
+      console.error(`Would launch Cursor agent targeting ${prUrl} with prompt: "${prompt.slice(0, 120)}${prompt.length > 120 ? "..." : ""}"`);
+      return;
+    }
+    const id = await launchAgentForPrUrl(cursorApiKey, prUrl, prompt);
+    console.error(`${ANSI.green}Cursor agent launched targeting PR #${targetPr}: ${id}${ANSI.reset}`);
+    return;
+  }
+
   if (dryRun) {
     console.error(`Would launch Cursor agent for ${issueUrl} with prompt: "${prompt.slice(0, 120)}${prompt.length > 120 ? "..." : ""}"`);
     return;
@@ -279,10 +293,18 @@ async function main(): Promise<void> {
   const bodyFilePath = bodyFileIdx >= 0 ? args[bodyFileIdx + 1] : null;
   const templateIdx = args.indexOf("--template");
   const templatePath = templateIdx >= 0 ? args[templateIdx + 1] : null;
+  const prIdx = args.indexOf("--pr");
+  const targetPrRaw = prIdx >= 0 ? args[prIdx + 1] : null;
+  const targetPr = targetPrRaw ? parseInt(targetPrRaw, 10) : null;
+  if (prIdx >= 0 && (!Number.isInteger(targetPr) || !targetPr || targetPr <= 0)) {
+    console.error("Error: --pr requires a valid pull request number");
+    process.exit(1);
+  }
   const filtered = args.filter((a, i) => {
-    if (["--dry-run", "--no-comment", "--no-template", "--body-file", "--template"].includes(a)) return false;
+    if (["--dry-run", "--no-comment", "--no-template", "--body-file", "--template", "--pr"].includes(a)) return false;
     if (bodyFileIdx >= 0 && i === bodyFileIdx + 1) return false;
     if (templateIdx >= 0 && i === templateIdx + 1) return false;
+    if (prIdx >= 0 && i === prIdx + 1) return false;
     return true;
   });
 
@@ -300,6 +322,7 @@ Options:
                      .github/ISSUE_TEMPLATE/issue_template.md, issue_template.md, docs/issue_template.md)
   --no-template      Skip template, use only body
   --no-comment       Do not add the agent instruction comment
+  --pr NUMBER        Update an existing PR branch instead of creating a new one (Cursor API only)
   --dry-run          Show what would be created without creating
 
 Examples:
@@ -398,6 +421,11 @@ Examples:
   const cursorApiKey = config?.cursorApiKey?.trim() || null;
   const shouldUseCursorApi = agent === "cursor" && cursorApiKey !== null;
 
+  if (targetPr && !shouldUseCursorApi) {
+    console.error("Error: --pr requires the Cursor API (agent=cursor with cursorApiKey configured)");
+    process.exit(1);
+  }
+
   const isInteractive = stdout.isTTY;
 
   if (!title && !isInteractive) {
@@ -441,7 +469,7 @@ Examples:
     if (issueNumber) {
       if (comment) {
         if (shouldUseCursorApi) {
-          await sendInstructionViaCursorApi(repo, issueNumber, agent, comment, cursorApiKey!, dryRun);
+          await sendInstructionViaCursorApi(repo, issueNumber, agent, comment, cursorApiKey!, dryRun, targetPr);
         } else {
           addComment(repo, issueNumber, comment, dryRun);
         }
@@ -449,7 +477,9 @@ Examples:
       const url = `https://github.com/${repo}/issues/${issueNumber}`;
       console.log(url);
       if (!dryRun && comment) {
-        if (shouldUseCursorApi) {
+        if (shouldUseCursorApi && targetPr) {
+          console.error(`${ANSI.green}Sent instruction to Cursor API targeting PR #${targetPr}.${ANSI.reset}`);
+        } else if (shouldUseCursorApi) {
           console.error(`${ANSI.green}Sent instruction to Cursor API (instead of issue comment).${ANSI.reset}`);
         } else {
           console.error(`${ANSI.green}Commented: ${comment}${ANSI.reset}`);

--- a/lib/services/status-actions.ts
+++ b/lib/services/status-actions.ts
@@ -9,6 +9,7 @@ import {
 } from "../gh.js";
 import type { WorkflowRun } from "../types.js";
 import { sendReplyViaCursorApi } from "../cursor-replies.js";
+import { launchAgentForPrUrl, launchAgentForRepository } from "../cursor-api.js";
 import { invalidateStatusCache } from "./status-service.js";
 
 const UP_TO_DATE_ERRORS = ["nothing to merge", "already up to date"];
@@ -442,13 +443,20 @@ export async function createIssueWithAgentComment(params: {
   body: string;
   agent: string;
   templateChoice: 0 | 1 | 2 | 3;
-}): Promise<{ issueNumber: number; commentAdded: boolean }> {
-  const { repo, title, body, agent, templateChoice } = params;
+  cursorApiKey?: string | null;
+  targetPr?: number | null;
+}): Promise<{ issueNumber: number; commentAdded: boolean; cursorAgentLaunched: boolean }> {
+  const { repo, title, body, agent, templateChoice, cursorApiKey, targetPr } = params;
   validateRepo(repo);
   const validatedAgent = validateAgent(agent);
   const trimmedTitle = title.trim();
   if (!trimmedTitle) {
     throw new Error("issue title cannot be empty");
+  }
+
+  const shouldUseCursorApi = validatedAgent === "cursor" && Boolean(cursorApiKey);
+  if (targetPr && !shouldUseCursorApi) {
+    throw new Error("targetPr requires the Cursor API (agent=cursor with cursorApiKey configured)");
   }
 
   const issueBody = body.trim() || ".";
@@ -469,12 +477,40 @@ export async function createIssueWithAgentComment(params: {
   const issueNumber = parseInt(match[1], 10);
 
   const selectedTemplate = getIssueTemplateComment(validatedAgent, templateChoice);
-  if (selectedTemplate) {
-    await ghQuietAsync("issue", "comment", String(issueNumber), "--repo", repo, "--body", selectedTemplate);
-    return { issueNumber, commentAdded: true };
+  if (!selectedTemplate) {
+    return { issueNumber, commentAdded: false, cursorAgentLaunched: false };
   }
 
-  return { issueNumber, commentAdded: false };
+  if (shouldUseCursorApi) {
+    const issueUrl = `https://github.com/${repo}/issues/${issueNumber}`;
+    const instruction = stripMention(selectedTemplate, validatedAgent);
+    const prompt = `${instruction}\n\nIssue: ${issueUrl}`;
+
+    if (targetPr) {
+      const prUrl = `https://github.com/${repo}/pull/${targetPr}`;
+      await launchAgentForPrUrl(cursorApiKey!, prUrl, prompt);
+    } else {
+      await launchAgentForRepository(
+        cursorApiKey!,
+        `https://github.com/${repo}`,
+        prompt,
+        { autoCreatePr: true, openAsCursorGithubApp: true }
+      );
+    }
+    return { issueNumber, commentAdded: false, cursorAgentLaunched: true };
+  }
+
+  await ghQuietAsync("issue", "comment", String(issueNumber), "--repo", repo, "--body", selectedTemplate);
+  return { issueNumber, commentAdded: true, cursorAgentLaunched: false };
+}
+
+function stripMention(comment: string, agent: string): string {
+  const mention = `@${agent}`;
+  const trimmed = comment.trim();
+  if (trimmed.toLowerCase().startsWith(mention.toLowerCase())) {
+    return trimmed.slice(mention.length).trimStart();
+  }
+  return trimmed;
 }
 
 export function getIssueTemplateComment(agent: string, templateChoice: 0 | 1 | 2 | 3): string | null {

--- a/web/public/app.js
+++ b/web/public/app.js
@@ -14,6 +14,7 @@ const issueTitleEl = document.getElementById("issueTitle");
 const issueBodyEl = document.getElementById("issueBody");
 const issueAgentEl = document.getElementById("issueAgent");
 const issueTemplateEl = document.getElementById("issueTemplate");
+const issuePrEl = document.getElementById("issuePr");
 const selectAllCheckboxEl = document.getElementById("selectAllCheckbox");
 const chainMergeControlsEl = document.getElementById("chainMergeControls");
 const chainMergeBtnEl = document.getElementById("chainMergeBtn");
@@ -2051,19 +2052,25 @@ commentFilterInputEl.addEventListener("change", () => {
 issueFormEl.addEventListener("submit", async (event) => {
   event.preventDefault();
   try {
+    const payload = {
+      repo: issueRepoEl.value.trim(),
+      title: issueTitleEl.value.trim(),
+      body: issueBodyEl.value.trim(),
+      agent: issueAgentEl.value,
+      templateChoice: Number(issueTemplateEl.value),
+    };
+    const prValue = issuePrEl.value.trim();
+    if (prValue) {
+      payload.pr = Number(prValue);
+    }
     const result = await api("/api/issues", {
       method: "POST",
-      body: JSON.stringify({
-        repo: issueRepoEl.value.trim(),
-        title: issueTitleEl.value.trim(),
-        body: issueBodyEl.value.trim(),
-        agent: issueAgentEl.value,
-        templateChoice: Number(issueTemplateEl.value),
-      }),
+      body: JSON.stringify(payload),
     });
     setStatus(result.message);
     issueTitleEl.value = "";
     issueBodyEl.value = "";
+    issuePrEl.value = "";
   } catch (error) {
     setStatus(error.message);
   }

--- a/web/public/index.html
+++ b/web/public/index.html
@@ -133,6 +133,7 @@
             <option value="3">Fix</option>
           </select>
         </label>
+        <label class="field-pr">Update PR <input id="issuePr" type="number" min="1" placeholder="PR # (optional)"></label>
         <button class="field-submit" type="submit">Create issue</button>
       </form>
     </section>

--- a/web/server.ts
+++ b/web/server.ts
@@ -346,20 +346,33 @@ async function handleApi(req: IncomingMessage, url: URL, res: ServerResponse): P
     if (![0, 1, 2, 3].includes(templateChoice)) {
       throw new Error("templateChoice must be one of: 0, 1, 2, 3");
     }
+    const targetPr = body.pr ? Number(body.pr) : null;
+    if (targetPr !== null && (!Number.isInteger(targetPr) || targetPr <= 0)) {
+      throw new Error("pr must be a valid pull request number");
+    }
+    const cursorApiKey = loadConfig()?.cursorApiKey?.trim() || null;
     const result = await createIssueWithAgentComment({
       repo,
       title,
       body: issueBody,
       agent,
       templateChoice: templateChoice as 0 | 1 | 2 | 3,
+      cursorApiKey,
+      targetPr,
     });
     sendJson(res, 200, {
       ok: true,
       issueNumber: result.issueNumber,
       commentAdded: result.commentAdded,
-      message: result.commentAdded
-        ? `Created issue #${result.issueNumber} with comment`
-        : `Created issue #${result.issueNumber}`,
+      cursorAgentLaunched: result.cursorAgentLaunched,
+      targetPr: targetPr ?? undefined,
+      message: result.cursorAgentLaunched
+        ? targetPr
+          ? `Created issue #${result.issueNumber}, Cursor agent targeting PR #${targetPr}`
+          : `Created issue #${result.issueNumber}, Cursor agent launched`
+        : result.commentAdded
+          ? `Created issue #${result.issueNumber} with comment`
+          : `Created issue #${result.issueNumber}`,
     });
     return;
   }


### PR DESCRIPTION
## Summary
This PR adds the ability to target an existing pull request when creating an issue with a Cursor agent instruction, instead of always creating a new PR. This is useful for directing the agent to work on an already-open PR branch.

## Key Changes
- **New `--pr` flag** in `create-issue` command to specify a target PR number (Cursor API only)
- **Updated `createIssueWithAgentComment` function** to accept optional `cursorApiKey` and `targetPr` parameters
- **New `launchAgentForPrUrl` integration** to launch the Cursor agent targeting a specific PR URL instead of the repository
- **Added `stripMention` helper function** to remove agent mentions from template comments before sending to Cursor API
- **Web UI enhancements**:
  - Added optional PR number input field in the issue creation form
  - Updated API endpoint to accept and handle the `pr` parameter
  - Improved response messages to indicate when agent is targeting a specific PR
- **Validation** to ensure `--pr` flag is only used with Cursor API (requires `agent=cursor` and `cursorApiKey` configured)

## Implementation Details
- When `targetPr` is provided with Cursor API enabled, the agent is launched via `launchAgentForPrUrl` targeting the specific PR instead of creating a new one
- The return value of `createIssueWithAgentComment` now includes `cursorAgentLaunched` flag to distinguish between comment-based and API-based agent invocations
- Template comments are stripped of agent mentions before being sent to the Cursor API as prompts
- Comprehensive validation ensures the feature is only used when properly configured

https://claude.ai/code/session_01QgBkChVxRZ6yeHJysdDb68