### PR TITLE
Hide merged standalone branches in web status

### DIFF
--- a/lib/gh.ts
+++ b/lib/gh.ts
@@ -469,6 +469,15 @@ export async function listBranchesAsync(repo: string): Promise<string[]> {
   return out.trim() ? out.trim().split("\n") : [];
 }
 
+export function getDefaultBranch(repo: string): string {
+  const out = gh("api", `repos/${repo}`, "-q", ".default_branch");
+  const branch = out.trim();
+  if (!branch) {
+    throw new Error(`Could not determine default branch for ${repo}`);
+  }
+  return branch;
+}
+
 export async function getDefaultBranchAsync(repo: string): Promise<string> {
   const out = await ghQuietAsync("api", `repos/${repo}`, "-q", ".default_branch");
   const branch = out.trim();
@@ -476,6 +485,36 @@ export async function getDefaultBranchAsync(repo: string): Promise<string> {
     throw new Error(`Could not determine default branch for ${repo}`);
   }
   return branch;
+}
+
+function parseAheadBy(value: string, repo: string, baseBranch: string, headBranch: string): number {
+  const aheadBy = Number.parseInt(value.trim(), 10);
+  if (!Number.isInteger(aheadBy) || aheadBy < 0) {
+    throw new Error(
+      `Could not determine commit delta for ${repo} (${baseBranch}...${headBranch})`
+    );
+  }
+  return aheadBy;
+}
+
+export function branchHasUniqueCommits(repo: string, baseBranch: string, headBranch: string): boolean {
+  const out = gh(
+    "api",
+    `repos/${repo}/compare/${encodeURIComponent(baseBranch)}...${encodeURIComponent(headBranch)}`,
+    "-q",
+    ".ahead_by"
+  );
+  return parseAheadBy(out, repo, baseBranch, headBranch) > 0;
+}
+
+export async function branchHasUniqueCommitsAsync(repo: string, baseBranch: string, headBranch: string): Promise<boolean> {
+  const out = await ghQuietAsync(
+    "api",
+    `repos/${repo}/compare/${encodeURIComponent(baseBranch)}...${encodeURIComponent(headBranch)}`,
+    "-q",
+    ".ahead_by"
+  );
+  return parseAheadBy(out, repo, baseBranch, headBranch) > 0;
 }
 
 const COMMIT_DELIM = "\x01";

--- a/lib/gh.ts
+++ b/lib/gh.ts
@@ -517,6 +517,62 @@ export async function branchHasUniqueCommitsAsync(repo: string, baseBranch: stri
   return parseAheadBy(out, repo, baseBranch, headBranch) > 0;
 }
 
+interface RepoCommitListItem {
+  commit?: {
+    message?: string;
+  };
+}
+
+export function mergeCommitMentionsBranch(message: string, branchName: string): boolean {
+  const normalizedMessage = message.toLowerCase();
+  const normalizedBranch = branchName.toLowerCase();
+  if (!normalizedMessage.includes("merge pull request")) {
+    return false;
+  }
+  return normalizedMessage.includes(`/${normalizedBranch}`) || normalizedMessage.includes(` ${normalizedBranch}`);
+}
+
+function parseRepoCommitList(output: string): RepoCommitListItem[] {
+  const parsed = JSON.parse(output || "[]") as unknown;
+  return Array.isArray(parsed) ? parsed as RepoCommitListItem[] : [];
+}
+
+export function hasNewerMergeCommitForBranch(
+  repo: string,
+  defaultBranch: string,
+  headBranch: string,
+  since: Date
+): boolean {
+  const out = gh(
+    "api",
+    `repos/${repo}/commits`,
+    "--paginate",
+    "-f", `sha=${defaultBranch}`,
+    "-f", `since=${since.toISOString()}`,
+    "-f", "per_page=100"
+  );
+  const commits = parseRepoCommitList(out);
+  return commits.some((item) => mergeCommitMentionsBranch(String(item.commit?.message || ""), headBranch));
+}
+
+export async function hasNewerMergeCommitForBranchAsync(
+  repo: string,
+  defaultBranch: string,
+  headBranch: string,
+  since: Date
+): Promise<boolean> {
+  const out = await ghQuietAsync(
+    "api",
+    `repos/${repo}/commits`,
+    "--paginate",
+    "-f", `sha=${defaultBranch}`,
+    "-f", `since=${since.toISOString()}`,
+    "-f", "per_page=100"
+  );
+  const commits = parseRepoCommitList(out);
+  return commits.some((item) => mergeCommitMentionsBranch(String(item.commit?.message || ""), headBranch));
+}
+
 const COMMIT_DELIM = "\x01";
 
 export interface CommitInfo {

--- a/lib/services/status-service.ts
+++ b/lib/services/status-service.ts
@@ -1,9 +1,13 @@
 import {
   AGENT_BRANCH_PATTERNS,
+  branchHasUniqueCommits,
+  branchHasUniqueCommitsAsync,
   getAgentForPR,
   getCurrentUser,
   getCommitInfo,
   getCommitInfoAsync,
+  getDefaultBranch,
+  getDefaultBranchAsync,
   getUnresolvedCommentCounts,
   getUnresolvedCommentCountsAsync,
   listBranches,
@@ -191,12 +195,59 @@ function commitTitle(message: string | undefined, fallback: string): string {
 }
 
 export function filterStandaloneBranches(branches: string[], prs: Pick<StatusBasePR, "headRefName" | "baseRefName">[]): string[] {
+  return filterStandaloneBranchesWithoutMerged(branches, prs, []);
+}
+
+export function filterStandaloneBranchesWithoutMerged(
+  branches: string[],
+  prs: Pick<StatusBasePR, "headRefName" | "baseRefName">[],
+  mergedBranches: Iterable<string>
+): string[] {
   const prHeadBranches = new Set<string>();
   for (const pr of prs) {
     prHeadBranches.add(pr.headRefName);
   }
+  const mergedBranchSet = new Set(mergedBranches);
 
-  return branches.filter((branch) => getAgentForBranch(branch) && !prHeadBranches.has(branch));
+  return branches.filter(
+    (branch) => getAgentForBranch(branch) && !prHeadBranches.has(branch) && !mergedBranchSet.has(branch)
+  );
+}
+
+function getMergedStandaloneBranches(
+  repo: string,
+  branches: string[],
+  defaultBranch: string
+): Set<string> {
+  const mergedBranches = new Set<string>();
+  for (const branch of branches) {
+    try {
+      if (!branchHasUniqueCommits(repo, defaultBranch, branch)) {
+        mergedBranches.add(branch);
+      }
+    } catch {
+      // Keep uncertain branches visible rather than hiding actionable work.
+    }
+  }
+  return mergedBranches;
+}
+
+async function getMergedStandaloneBranchesAsync(
+  repo: string,
+  branches: string[],
+  defaultBranch: string
+): Promise<Set<string>> {
+  const merged = await Promise.all(
+    branches.map(async (branch) => {
+      try {
+        return await branchHasUniqueCommitsAsync(repo, defaultBranch, branch) ? null : branch;
+      } catch {
+        // Keep uncertain branches visible rather than hiding actionable work.
+        return null;
+      }
+    })
+  );
+  return new Set(merged.filter((branch): branch is string => branch !== null));
 }
 
 function toPRWithStatus(repo: string, raw: StatusBasePR, now: number): PRWithStatus {
@@ -303,7 +354,11 @@ function buildStandaloneBranchRowsSync(
   prs: StatusBasePR[],
   now: number
 ): BranchWithStatus[] {
-  const candidateBranches = filterStandaloneBranches(listBranches(repo), prs);
+  const allBranches = listBranches(repo);
+  const allCandidateBranches = filterStandaloneBranches(allBranches, prs);
+  const defaultBranch = getDefaultBranch(repo);
+  const mergedBranches = getMergedStandaloneBranches(repo, allCandidateBranches, defaultBranch);
+  const candidateBranches = filterStandaloneBranchesWithoutMerged(allBranches, prs, mergedBranches);
   const rows: BranchWithStatus[] = [];
 
   for (const branch of candidateBranches) {
@@ -323,7 +378,11 @@ async function buildStandaloneBranchRows(
   prs: StatusBasePR[],
   now: number
 ): Promise<BranchWithStatus[]> {
-  const candidateBranches = filterStandaloneBranches(await listBranchesAsync(repo), prs);
+  const allBranches = await listBranchesAsync(repo);
+  const allCandidateBranches = filterStandaloneBranches(allBranches, prs);
+  const defaultBranch = await getDefaultBranchAsync(repo);
+  const mergedBranches = await getMergedStandaloneBranchesAsync(repo, allCandidateBranches, defaultBranch);
+  const candidateBranches = filterStandaloneBranchesWithoutMerged(allBranches, prs, mergedBranches);
   const rows = await Promise.all(candidateBranches.map(async (branch) => {
     try {
       const info = await getCommitInfoAsync(repo, branch, true);

--- a/lib/services/status-service.ts
+++ b/lib/services/status-service.ts
@@ -2,6 +2,8 @@ import {
   AGENT_BRANCH_PATTERNS,
   branchHasUniqueCommits,
   branchHasUniqueCommitsAsync,
+  hasNewerMergeCommitForBranch,
+  hasNewerMergeCommitForBranchAsync,
   getAgentForPR,
   getCurrentUser,
   getCommitInfo,
@@ -224,6 +226,11 @@ function getMergedStandaloneBranches(
     try {
       if (!branchHasUniqueCommits(repo, defaultBranch, branch)) {
         mergedBranches.add(branch);
+        continue;
+      }
+      const branchTip = getCommitInfo(repo, branch);
+      if (branchTip.date && hasNewerMergeCommitForBranch(repo, defaultBranch, branch, branchTip.date)) {
+        mergedBranches.add(branch);
       }
     } catch {
       // Keep uncertain branches visible rather than hiding actionable work.
@@ -240,7 +247,14 @@ async function getMergedStandaloneBranchesAsync(
   const merged = await Promise.all(
     branches.map(async (branch) => {
       try {
-        return await branchHasUniqueCommitsAsync(repo, defaultBranch, branch) ? null : branch;
+        if (!await branchHasUniqueCommitsAsync(repo, defaultBranch, branch)) {
+          return branch;
+        }
+        const branchTip = await getCommitInfoAsync(repo, branch);
+        if (branchTip.date && await hasNewerMergeCommitForBranchAsync(repo, defaultBranch, branch, branchTip.date)) {
+          return branch;
+        }
+        return null;
       } catch {
         // Keep uncertain branches visible rather than hiding actionable work.
         return null;

--- a/tests/status-service.test.ts
+++ b/tests/status-service.test.ts
@@ -1,6 +1,12 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { applyCIStatus, filterPRsByStatusScope, filterStandaloneBranches, hasPRConflicts } from "../lib/services/status-service.js";
+import {
+  applyCIStatus,
+  filterPRsByStatusScope,
+  filterStandaloneBranches,
+  filterStandaloneBranchesWithoutMerged,
+  hasPRConflicts,
+} from "../lib/services/status-service.js";
 import type { PRWithStatus, StatusBasePR } from "../lib/services/status-types.js";
 
 function makeRow(): PRWithStatus {
@@ -129,4 +135,19 @@ test("filterStandaloneBranches keeps only standalone agent branches", () => {
   );
 
   assert.deepEqual(filtered, ["cursor/ready", "cursor/base-for-stack", "claude/standalone"]);
+});
+
+test("filterStandaloneBranchesWithoutMerged excludes branches already merged into default", () => {
+  const filtered = filterStandaloneBranchesWithoutMerged(
+    [
+      "cursor/merged",
+      "cursor/ready",
+      "claude/merged-too",
+      "main",
+    ],
+    [],
+    ["cursor/merged", "claude/merged-too"]
+  );
+
+  assert.deepEqual(filtered, ["cursor/ready"]);
 });

--- a/tests/status-service.test.ts
+++ b/tests/status-service.test.ts
@@ -1,5 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import { mergeCommitMentionsBranch } from "../lib/gh.js";
 import {
   applyCIStatus,
   filterPRsByStatusScope,
@@ -150,4 +151,34 @@ test("filterStandaloneBranchesWithoutMerged excludes branches already merged int
   );
 
   assert.deepEqual(filtered, ["cursor/ready"]);
+});
+
+test("mergeCommitMentionsBranch matches GitHub merge commit messages for the branch", () => {
+  assert.equal(
+    mergeCommitMentionsBranch(
+      "Merge pull request #38 from jonathanKingston/cursor/web-standalone-branches",
+      "cursor/web-standalone-branches"
+    ),
+    true
+  );
+});
+
+test("mergeCommitMentionsBranch ignores unrelated merge commits", () => {
+  assert.equal(
+    mergeCommitMentionsBranch(
+      "Merge pull request #41 from jonathanKingston/cursor/some-other-branch",
+      "cursor/web-standalone-branches"
+    ),
+    false
+  );
+});
+
+test("mergeCommitMentionsBranch ignores non-merge commit messages that mention the branch", () => {
+  assert.equal(
+    mergeCommitMentionsBranch(
+      "Follow up on cursor/web-standalone-branches after review",
+      "cursor/web-standalone-branches"
+    ),
+    false
+  );
 });

--- a/web/public/app.js
+++ b/web/public/app.js
@@ -601,7 +601,7 @@ function branchCell(row) {
   main.className = "pr-main";
 
   const head = document.createElement("div");
-  head.className = "pr-head";
+  head.className = "pr-head branch-head";
 
   const kind = createBadge("branch", "branch-badge");
   const branch = document.createElement("a");

--- a/web/public/styles.css
+++ b/web/public/styles.css
@@ -250,6 +250,24 @@ td.pr-cell {
   gap: 0.35rem;
 }
 
+.branch-head {
+  display: flex;
+  width: 100%;
+  align-items: flex-start;
+}
+
+.branch-head .pr-number {
+  flex: 1 1 auto;
+  min-width: 0;
+  white-space: normal;
+  overflow-wrap: anywhere;
+}
+
+.branch-head .ci-indicator {
+  margin-left: auto;
+  align-self: center;
+}
+
 .pr-number:hover {
   text-decoration: underline;
 }


### PR DESCRIPTION
## Summary
- hide standalone agent branches in the web status view once they no longer have unique commits beyond the default branch
- add regression coverage for merged standalone branch filtering so the status pipeline keeps this behavior stable
- align branch-row CI indicators in the web dashboard so the status dot stays visually anchored beside long branch names

## Test plan
- [x] npm test
- [x] npm run build

Made with [Cursor](https://cursor.com)