### PR TITLE
Wire API-layer mock provider so TUI and Web work in mock mode

### DIFF
--- a/commands/approval.ts
+++ b/commands/approval.ts
@@ -16,6 +16,7 @@
  *   - Optionally contain the query in title or body
  */
 
+import { initializeRuntime } from "../lib/runtime-init.js";
 import { getOriginRepo } from "../lib/utils.js";
 import type { ExecError } from "../lib/types.js";
 import {
@@ -23,6 +24,8 @@ import {
 } from "../lib/gh.js";
 import { parseStandardFlags } from "../lib/args.js";
 import { filterPRs, getUserForDisplay, buildFetchMessage } from "../lib/filters.js";
+
+initializeRuntime();
 
 const autoMergeStrategyCache = new Map<string, string>();
 

--- a/commands/artifacts.ts
+++ b/commands/artifacts.ts
@@ -3,6 +3,7 @@
  *
  * Usage: copse artifacts <repo> <pr-number> [--download ABSOLUTE_PATH] [--out FILE]
  */
+import { initializeRuntime } from "../lib/runtime-init.js";
 import { validateRepo } from "../lib/gh.js";
 import { loadConfig } from "../lib/config.js";
 import { findLatestAgentByPrUrl, getArtifactDownloadUrl, listAgentArtifacts } from "../lib/cursor-api.js";
@@ -12,6 +13,8 @@ import { pipeline } from "node:stream/promises";
 import { Readable } from "node:stream";
 import type { ReadableStream as NodeReadableStream } from "node:stream/web";
 import { basename as pathBasename } from "node:path";
+
+initializeRuntime();
 
 function usage(): string {
   return `Usage: copse artifacts <repo> <pr-number> [--download ABSOLUTE_PATH] [--out FILE]

--- a/commands/create-issue.ts
+++ b/commands/create-issue.ts
@@ -28,10 +28,13 @@ import { execFileSync, execSync } from "child_process";
 import { readFileSync, writeFileSync, unlinkSync, existsSync, readdirSync } from "fs";
 import { resolve, join } from "path";
 import { tmpdir } from "os";
+import { initializeRuntime } from "../lib/runtime-init.js";
 import { REPO_PATTERN, validateRepo, validateAgent } from "../lib/gh.js";
 import { getOriginRepo } from "../lib/utils.js";
 import { loadConfig } from "../lib/config.js";
 import { launchAgentForRepository } from "../lib/cursor-api.js";
+
+initializeRuntime();
 
 const ANSI = {
   reset: "\x1b[0m",

--- a/commands/create-prs.ts
+++ b/commands/create-prs.ts
@@ -14,11 +14,14 @@
 import { execFileSync } from "child_process";
 import { readFileSync } from "fs";
 import { resolve } from "path";
+import { initializeRuntime } from "../lib/runtime-init.js";
 import {
   validateRepo, validateAgent, gh, getCommitInfo, AGENT_BRANCH_PATTERNS, listBranches,
 } from "../lib/gh.js";
 import { parseStandardFlags, parseHoursOption, parseBaseOption, parseTemplateOption, calculateSinceDate } from "../lib/args.js";
 import { getUserForDisplay } from "../lib/filters.js";
+
+initializeRuntime();
 
 const DEFAULT_TEMPLATE_URL =
   "https://raw.githubusercontent.com/duckduckgo/content-scope-scripts/main/.github/pull_request_template.md";

--- a/commands/init.ts
+++ b/commands/init.ts
@@ -17,8 +17,11 @@ import { stdin, stdout } from "node:process";
 import { writeFileSync, existsSync, mkdirSync } from "fs";
 import { resolve, dirname, join } from "path";
 import { homedir } from "os";
+import { initializeRuntime } from "../lib/runtime-init.js";
 import { REPO_PATTERN } from "../lib/gh.js";
 import { getOriginRepo } from "../lib/utils.js";
+
+initializeRuntime();
 
 const ANSI = {
   reset: "\x1b[0m",

--- a/commands/pr-comments.ts
+++ b/commands/pr-comments.ts
@@ -8,6 +8,7 @@
 
 import * as readline from "node:readline/promises";
 import { stdin, stdout } from "node:process";
+import { initializeRuntime } from "../lib/runtime-init.js";
 import { getOriginRepo, isBotComment } from "../lib/utils.js";
 import { formatCommentBody } from "../lib/format.js";
 import type { PR, PRReviewComment } from "../lib/types.js";
@@ -33,6 +34,8 @@ import {
   resolveTemplatesPath,
 } from "../lib/templates.js";
 import type { ExecError } from "../lib/types.js";
+
+initializeRuntime();
 
 const ANSI = {
   reset: "\x1b[0m",

--- a/commands/pr-status.ts
+++ b/commands/pr-status.ts
@@ -7,11 +7,14 @@
 
 import { getOriginRepo, hyperlink, getTerminalColumns } from "../lib/utils.js";
 import type { WorkflowRun } from "../lib/types.js";
+import { initializeRuntime } from "../lib/runtime-init.js";
 import {
   REPO_PATTERN, validateRepo, listOpenPRs, listWorkflowRuns,
 } from "../lib/gh.js";
 import { parseStandardFlags } from "../lib/args.js";
 import { filterPRs, getUserForDisplay, buildFetchMessage } from "../lib/filters.js";
+
+initializeRuntime();
 
 function main(): void {
   const { flags, filtered } = parseStandardFlags(process.argv.slice(2));

--- a/commands/rerun-failed.ts
+++ b/commands/rerun-failed.ts
@@ -6,6 +6,7 @@
  *        Omit agent to include both cursor and claude branches.
  */
 
+import { initializeRuntime } from "../lib/runtime-init.js";
 import { getOriginRepo } from "../lib/utils.js";
 import type { WorkflowRun } from "../lib/types.js";
 import {
@@ -13,6 +14,8 @@ import {
 } from "../lib/gh.js";
 import { parseStandardFlags, parseHoursOption, calculateSinceDate } from "../lib/args.js";
 import { getUserForDisplay } from "../lib/filters.js";
+
+initializeRuntime();
 
 function listFailedRuns(repo: string, branch: string): WorkflowRun[] {
   try {

--- a/commands/status.ts
+++ b/commands/status.ts
@@ -12,6 +12,7 @@ import { basename as pathBasename } from "node:path";
 import { pipeline } from "node:stream/promises";
 import { Readable } from "node:stream";
 import type { ReadableStream as NodeReadableStream } from "node:stream/web";
+import { initializeRuntime } from "../lib/runtime-init.js";
 import {
   REPO_PATTERN,
   ghQuietAsync,
@@ -50,6 +51,8 @@ import {
   resolveTemplatesPath,
 } from "../lib/templates.js";
 import { formatBytes } from "../lib/format.js";
+
+initializeRuntime();
 
 function execAsync(command: string, args: string[]): Promise<string> {
   return new Promise((resolve, reject) => {

--- a/commands/update-main.ts
+++ b/commands/update-main.ts
@@ -6,11 +6,14 @@
  */
 
 import type { ExecError, MergeResult } from "../lib/types.js";
+import { initializeRuntime } from "../lib/runtime-init.js";
 import {
   validateRepo, gh, listOpenPRs,
 } from "../lib/gh.js";
 import { parseStandardFlags, parseBaseOption } from "../lib/args.js";
 import { filterPRs, getUserForDisplay, buildFetchMessage } from "../lib/filters.js";
+
+initializeRuntime();
 
 function mergeMainIntoBranch(repo: string, headRef: string, baseRef: string, dryRun: boolean): MergeResult {
   if (dryRun) return { ok: true, skipped: true };

--- a/commands/web.ts
+++ b/commands/web.ts
@@ -1,5 +1,8 @@
 import { execFile } from "node:child_process";
+import { initializeRuntime } from "../lib/runtime-init.js";
 import { runWebServer } from "../web/server.js";
+
+initializeRuntime();
 
 function maybeOpenBrowser(url: string): void {
   const opener = process.platform === "darwin" ? "open" : "xdg-open";

--- a/copse.ts
+++ b/copse.ts
@@ -5,6 +5,7 @@ import { fileURLToPath } from "url";
 import { dirname, join } from "path";
 import type { CommandDef } from "./lib/types.js";
 import { ensureGh, GhNotFoundError, GhNotAuthenticatedError } from "./lib/gh.js";
+import { initializeRuntime } from "./lib/runtime-init.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -362,6 +363,7 @@ function runCommand(command: string, args: string[]): void {
 }
 
 function main(): void {
+  initializeRuntime();
   const args = process.argv.slice(2);
 
   if (args.length === 0) {

--- a/lib/api-provider.ts
+++ b/lib/api-provider.ts
@@ -1,0 +1,68 @@
+import type { PR, WorkflowRun, PRReviewComment, PRChangedFile } from "./types.js";
+import type { CursorAgent, CursorArtifact } from "./cursor-api.js";
+import type { Copserc } from "./config.js";
+
+export interface CommitInfoLike {
+  message?: string;
+  date: Date | null;
+  authorLogin: string;
+}
+
+export interface ApiProvider {
+  ensureGh?(): void;
+  getCurrentUser?(): string;
+
+  gh?(...args: string[]): string;
+  ghQuiet?(...args: string[]): string;
+  ghQuietAsync?(...args: string[]): Promise<string>;
+
+  listOpenPRs?(repo: string, fields: string[]): PR[];
+  listOpenPRsAsync?(repo: string, fields: string[]): Promise<PR[]>;
+  listWorkflowRuns?(repo: string, branch: string): WorkflowRun[];
+  listWorkflowRunsAsync?(repo: string, branch: string): Promise<WorkflowRun[]>;
+  listBranches?(repo: string): string[];
+  listBranchesAsync?(repo: string): Promise<string[]>;
+  getDefaultBranchAsync?(repo: string): Promise<string>;
+  getCommitInfo?(repo: string, branchRef: string, includeMessage?: boolean): CommitInfoLike;
+  getCommitInfoAsync?(repo: string, branchRef: string, includeMessage?: boolean): Promise<CommitInfoLike>;
+  listPRReviewComments?(repo: string, prNumber: number): PRReviewComment[];
+  listPRReviewCommentsAsync?(repo: string, prNumber: number): Promise<PRReviewComment[]>;
+  getUnresolvedCommentCounts?(repo: string, prNumbers: number[]): Map<number, number>;
+  getUnresolvedCommentCountsAsync?(repo: string, prNumbers: number[]): Promise<Map<number, number>>;
+  addPRCommentAsync?(repo: string, prNumber: number, body: string): Promise<void>;
+  replyToPRCommentAsync?(repo: string, prNumber: number, inReplyToId: number, body: string): Promise<void>;
+  listPRFiles?(repo: string, prNumber: number): PRChangedFile[];
+  listPRFilesAsync?(repo: string, prNumber: number): Promise<PRChangedFile[]>;
+
+  cursorListAgentsByPrUrl?(apiKey: string, prUrl: string): Promise<CursorAgent[]>;
+  cursorFindLatestAgentByPrUrl?(apiKey: string, prUrl: string): Promise<CursorAgent | null>;
+  cursorAddFollowup?(apiKey: string, agentId: string, text: string): Promise<string>;
+  cursorLaunchAgentForPrUrl?(apiKey: string, prUrl: string, text: string): Promise<string>;
+  cursorListAgentArtifacts?(apiKey: string, agentId: string): Promise<CursorArtifact[]>;
+  cursorGetArtifactDownloadUrl?(
+    apiKey: string,
+    agentId: string,
+    absolutePath: string
+  ): Promise<{ url: string; expiresAt?: string }>;
+
+  loadConfig?(cwd?: string): Copserc | null;
+  getConfiguredRepos?(cwd?: string): string[] | null;
+  getOriginRepo?(): string | null;
+  loadTemplates?(dirPath: string): Map<string, string>;
+
+  invalidateStatusCache?(): void;
+}
+
+let activeApiProvider: ApiProvider | null = null;
+
+export function setApiProvider(provider: ApiProvider): void {
+  activeApiProvider = provider;
+}
+
+export function getApiProvider(): ApiProvider | null {
+  return activeApiProvider;
+}
+
+export function resetApiProvider(): void {
+  activeApiProvider = null;
+}

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -10,11 +10,8 @@ import { readFileSync, existsSync } from "fs";
 import { join, resolve } from "path";
 import { homedir } from "os";
 import { getApiProvider } from "./api-provider.js";
-import { ensureMockProviderConfigured } from "./mock-mode.js";
 
 const CONFIG_FILENAME = ".copserc";
-
-ensureMockProviderConfigured();
 
 export interface Copserc {
   repos?: string[];

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -9,8 +9,12 @@
 import { readFileSync, existsSync } from "fs";
 import { join, resolve } from "path";
 import { homedir } from "os";
+import { getApiProvider } from "./api-provider.js";
+import { ensureMockProviderConfigured } from "./mock-mode.js";
 
 const CONFIG_FILENAME = ".copserc";
+
+ensureMockProviderConfigured();
 
 export interface Copserc {
   repos?: string[];
@@ -56,6 +60,10 @@ function loadConfigFromPath(configPath: string): Copserc | null {
 }
 
 export function loadConfig(cwd: string = process.cwd()): Copserc | null {
+  const provider = getApiProvider();
+  if (provider?.loadConfig) {
+    return provider.loadConfig(cwd);
+  }
   const homeConfig = join(homedir(), CONFIG_FILENAME);
   const globalConfig = loadConfigFromPath(homeConfig);
   if (globalConfig) return globalConfig;
@@ -67,6 +75,10 @@ export function loadConfig(cwd: string = process.cwd()): Copserc | null {
 }
 
 export function getConfiguredRepos(cwd: string = process.cwd()): string[] | null {
+  const provider = getApiProvider();
+  if (provider?.getConfiguredRepos) {
+    return provider.getConfiguredRepos(cwd);
+  }
   const config = loadConfig(cwd);
   if (!config?.repos || config.repos.length === 0) return null;
   return config.repos;

--- a/lib/cursor-api.ts
+++ b/lib/cursor-api.ts
@@ -1,7 +1,4 @@
 import { getApiProvider } from "./api-provider.js";
-import { ensureMockProviderConfigured } from "./mock-mode.js";
-
-ensureMockProviderConfigured();
 
 const CURSOR_API_BASE_URL = "https://api.cursor.com";
 const DEFAULT_LIST_LIMIT = 100;

--- a/lib/cursor-api.ts
+++ b/lib/cursor-api.ts
@@ -1,3 +1,8 @@
+import { getApiProvider } from "./api-provider.js";
+import { ensureMockProviderConfigured } from "./mock-mode.js";
+
+ensureMockProviderConfigured();
+
 const CURSOR_API_BASE_URL = "https://api.cursor.com";
 const DEFAULT_LIST_LIMIT = 100;
 
@@ -80,6 +85,10 @@ async function cursorRequest<T>(
 }
 
 export async function listAgentsByPrUrl(apiKey: string, prUrl: string): Promise<CursorAgent[]> {
+  const provider = getApiProvider();
+  if (provider?.cursorListAgentsByPrUrl) {
+    return provider.cursorListAgentsByPrUrl(apiKey, prUrl);
+  }
   const agents: CursorAgent[] = [];
   let cursor: string | null = null;
 
@@ -103,6 +112,10 @@ export async function listAgentsByPrUrl(apiKey: string, prUrl: string): Promise<
 }
 
 export async function findLatestAgentByPrUrl(apiKey: string, prUrl: string): Promise<CursorAgent | null> {
+  const provider = getApiProvider();
+  if (provider?.cursorFindLatestAgentByPrUrl) {
+    return provider.cursorFindLatestAgentByPrUrl(apiKey, prUrl);
+  }
   const agents = await listAgentsByPrUrl(apiKey, prUrl);
   if (agents.length === 0) return null;
 
@@ -115,6 +128,10 @@ export async function findLatestAgentByPrUrl(apiKey: string, prUrl: string): Pro
 }
 
 export async function addFollowup(apiKey: string, agentId: string, text: string): Promise<string> {
+  const provider = getApiProvider();
+  if (provider?.cursorAddFollowup) {
+    return provider.cursorAddFollowup(apiKey, agentId, text);
+  }
   const payload = {
     prompt: {
       text,
@@ -135,6 +152,10 @@ export async function addFollowup(apiKey: string, agentId: string, text: string)
 }
 
 export async function launchAgentForPrUrl(apiKey: string, prUrl: string, text: string): Promise<string> {
+  const provider = getApiProvider();
+  if (provider?.cursorLaunchAgentForPrUrl) {
+    return provider.cursorLaunchAgentForPrUrl(apiKey, prUrl, text);
+  }
   const payload = {
     prompt: {
       text,
@@ -179,6 +200,10 @@ export async function launchAgentForRepository(
 }
 
 export async function listAgentArtifacts(apiKey: string, agentId: string): Promise<CursorArtifact[]> {
+  const provider = getApiProvider();
+  if (provider?.cursorListAgentArtifacts) {
+    return provider.cursorListAgentArtifacts(apiKey, agentId);
+  }
   const response = await cursorRequest<CursorListArtifactsResponse>(
     apiKey,
     `/v0/agents/${encodeURIComponent(agentId)}/artifacts`,
@@ -192,6 +217,10 @@ export async function getArtifactDownloadUrl(
   agentId: string,
   absolutePath: string
 ): Promise<{ url: string; expiresAt?: string }> {
+  const provider = getApiProvider();
+  if (provider?.cursorGetArtifactDownloadUrl) {
+    return provider.cursorGetArtifactDownloadUrl(apiKey, agentId, absolutePath);
+  }
   const params = new URLSearchParams({ path: absolutePath });
   const response = await cursorRequest<CursorArtifactDownloadResponse>(
     apiKey,

--- a/lib/gh.ts
+++ b/lib/gh.ts
@@ -2,7 +2,6 @@ import { execFileSync, execFile } from "child_process";
 import type { PR, AgentPatternWithLabels, ExecError, WorkflowRun, PRReviewComment, PRChangedFile } from "./types.js";
 import { WATCH_INTERVAL_MS } from "./services/status-types.js";
 import { getApiProvider } from "./api-provider.js";
-import { ensureMockProviderConfigured } from "./mock-mode.js";
 
 export const REPO_PATTERN = /^[a-zA-Z0-9_.-]+\/[a-zA-Z0-9_.-]+$/;
 
@@ -30,10 +29,7 @@ const COAUTHOR_SCAN_COMMIT_COUNT = 100;
 let _interrupted = false;
 let _pipeStdio = false;
 
-ensureMockProviderConfigured();
-
 function activeProvider() {
-  ensureMockProviderConfigured();
   return getApiProvider();
 }
 

--- a/lib/gh.ts
+++ b/lib/gh.ts
@@ -1,6 +1,8 @@
 import { execFileSync, execFile } from "child_process";
 import type { PR, AgentPatternWithLabels, ExecError, WorkflowRun, PRReviewComment, PRChangedFile } from "./types.js";
 import { WATCH_INTERVAL_MS } from "./services/status-types.js";
+import { getApiProvider } from "./api-provider.js";
+import { ensureMockProviderConfigured } from "./mock-mode.js";
 
 export const REPO_PATTERN = /^[a-zA-Z0-9_.-]+\/[a-zA-Z0-9_.-]+$/;
 
@@ -27,6 +29,13 @@ const COAUTHOR_SCAN_COMMIT_COUNT = 100;
 
 let _interrupted = false;
 let _pipeStdio = false;
+
+ensureMockProviderConfigured();
+
+function activeProvider() {
+  ensureMockProviderConfigured();
+  return getApiProvider();
+}
 
 type CacheDecision = { ok: true; key: string; ttlMs: number } | { ok: false };
 
@@ -149,6 +158,11 @@ export class GhNotAuthenticatedError extends Error {
 
 /** Check that `gh` is installed and authenticated. */
 export function ensureGh(): void {
+  const provider = activeProvider();
+  if (provider?.ensureGh) {
+    provider.ensureGh();
+    return;
+  }
   try {
     execFileSync("gh", ["--version"], { stdio: "ignore" });
   } catch (e: unknown) {
@@ -168,6 +182,10 @@ export function isInterrupted(): boolean { return _interrupted; }
 export function setPipeStdio(on: boolean): void { _pipeStdio = on; }
 
 export function gh(...args: string[]): string {
+  const provider = activeProvider();
+  if (provider?.gh) {
+    return provider.gh(...args);
+  }
   const stdio = _pipeStdio ? "pipe" as const : undefined;
   const decision = cacheDecisionForGhArgs(args);
   if (decision.ok) {
@@ -201,6 +219,10 @@ export function gh(...args: string[]): string {
 
 /** Like gh() but suppresses stderr output (for use in TUI watch modes). */
 export function ghQuiet(...args: string[]): string {
+  const provider = activeProvider();
+  if (provider?.ghQuiet) {
+    return provider.ghQuiet(...args);
+  }
   const decision = cacheDecisionForGhArgs(args);
   if (decision.ok) {
     const now = Date.now();
@@ -233,6 +255,10 @@ export function ghQuiet(...args: string[]): string {
 
 /** Non-blocking variant of ghQuiet — keeps the event loop responsive for TUI key handling. */
 export function ghQuietAsync(...args: string[]): Promise<string> {
+  const provider = activeProvider();
+  if (provider?.ghQuietAsync) {
+    return provider.ghQuietAsync(...args);
+  }
   const decision = cacheDecisionForGhArgs(args);
   if (decision.ok) {
     const now = Date.now();
@@ -271,6 +297,10 @@ export function ghQuietAsync(...args: string[]): Promise<string> {
 
 let _cachedUser: string | null = null;
 export function getCurrentUser(): string {
+  const provider = activeProvider();
+  if (provider?.getCurrentUser) {
+    return provider.getCurrentUser();
+  }
   if (!_cachedUser) {
     _cachedUser = gh("api", "user", "-q", ".login").trim();
   }
@@ -406,6 +436,10 @@ export function checkPRsForAgentCoAuthors(
 }
 
 export function listOpenPRs(repo: string, fields: string[]): PR[] {
+  const provider = activeProvider();
+  if (provider?.listOpenPRs) {
+    return provider.listOpenPRs(repo, fields);
+  }
   const out = gh(
     "pr", "list",
     "--repo", repo,
@@ -417,6 +451,10 @@ export function listOpenPRs(repo: string, fields: string[]): PR[] {
 }
 
 export async function listOpenPRsAsync(repo: string, fields: string[]): Promise<PR[]> {
+  const provider = activeProvider();
+  if (provider?.listOpenPRsAsync) {
+    return provider.listOpenPRsAsync(repo, fields);
+  }
   const out = await ghQuietAsync(
     "pr", "list",
     "--repo", repo,
@@ -428,6 +466,10 @@ export async function listOpenPRsAsync(repo: string, fields: string[]): Promise<
 }
 
 export function listWorkflowRuns(repo: string, branch: string): WorkflowRun[] {
+  const provider = activeProvider();
+  if (provider?.listWorkflowRuns) {
+    return provider.listWorkflowRuns(repo, branch);
+  }
   try {
     const out = gh(
       "run", "list",
@@ -444,6 +486,10 @@ export function listWorkflowRuns(repo: string, branch: string): WorkflowRun[] {
 }
 
 export async function listWorkflowRunsAsync(repo: string, branch: string): Promise<WorkflowRun[]> {
+  const provider = activeProvider();
+  if (provider?.listWorkflowRunsAsync) {
+    return provider.listWorkflowRunsAsync(repo, branch);
+  }
   try {
     const out = await ghQuietAsync(
       "run", "list",
@@ -460,16 +506,28 @@ export async function listWorkflowRunsAsync(repo: string, branch: string): Promi
 }
 
 export function listBranches(repo: string): string[] {
+  const provider = activeProvider();
+  if (provider?.listBranches) {
+    return provider.listBranches(repo);
+  }
   const out = gh("api", `repos/${repo}/branches`, "--paginate", "-q", ".[].name");
   return out.trim() ? out.trim().split("\n") : [];
 }
 
 export async function listBranchesAsync(repo: string): Promise<string[]> {
+  const provider = activeProvider();
+  if (provider?.listBranchesAsync) {
+    return provider.listBranchesAsync(repo);
+  }
   const out = await ghQuietAsync("api", `repos/${repo}/branches`, "--paginate", "-q", ".[].name");
   return out.trim() ? out.trim().split("\n") : [];
 }
 
 export async function getDefaultBranchAsync(repo: string): Promise<string> {
+  const provider = activeProvider();
+  if (provider?.getDefaultBranchAsync) {
+    return provider.getDefaultBranchAsync(repo);
+  }
   const out = await ghQuietAsync("api", `repos/${repo}`, "-q", ".default_branch");
   const branch = out.trim();
   if (!branch) {
@@ -528,6 +586,10 @@ export function getResolvedCommentNodeIds(repo: string, prNumber: number): Set<s
 }
 
 export function listPRReviewComments(repo: string, prNumber: number): PRReviewComment[] {
+  const provider = activeProvider();
+  if (provider?.listPRReviewComments) {
+    return provider.listPRReviewComments(repo, prNumber);
+  }
   try {
     const out = gh(
       "api",
@@ -551,6 +613,11 @@ export function replyToPRComment(
   inReplyToId: number,
   body: string
 ): void {
+  const provider = activeProvider();
+  if (provider?.replyToPRCommentAsync) {
+    void provider.replyToPRCommentAsync(repo, prNumber, inReplyToId, body);
+    return;
+  }
   gh(
     "api",
     `repos/${repo}/pulls/${prNumber}/comments/${inReplyToId}/replies`,
@@ -565,6 +632,11 @@ export async function replyToPRCommentAsync(
   inReplyToId: number,
   body: string
 ): Promise<void> {
+  const provider = activeProvider();
+  if (provider?.replyToPRCommentAsync) {
+    await provider.replyToPRCommentAsync(repo, prNumber, inReplyToId, body);
+    return;
+  }
   await ghQuietAsync(
     "api",
     `repos/${repo}/pulls/${prNumber}/comments/${inReplyToId}/replies`,
@@ -620,6 +692,10 @@ export function resolveReviewThread(repo: string, prNumber: number, commentNodeI
 }
 
 export function getUnresolvedCommentCounts(repo: string, prNumbers: number[]): Map<number, number> {
+  const provider = activeProvider();
+  if (provider?.getUnresolvedCommentCounts) {
+    return provider.getUnresolvedCommentCounts(repo, prNumbers);
+  }
   if (prNumbers.length === 0) return new Map();
 
   const [owner, name] = repo.split("/");
@@ -667,6 +743,10 @@ export function getUnresolvedCommentCounts(repo: string, prNumbers: number[]): M
 }
 
 export async function getUnresolvedCommentCountsAsync(repo: string, prNumbers: number[]): Promise<Map<number, number>> {
+  const provider = activeProvider();
+  if (provider?.getUnresolvedCommentCountsAsync) {
+    return provider.getUnresolvedCommentCountsAsync(repo, prNumbers);
+  }
   if (prNumbers.length === 0) return new Map();
 
   const [owner, name] = repo.split("/");
@@ -755,6 +835,10 @@ export async function getResolvedCommentNodeIdsAsync(repo: string, prNumber: num
 }
 
 export async function listPRReviewCommentsAsync(repo: string, prNumber: number): Promise<PRReviewComment[]> {
+  const provider = activeProvider();
+  if (provider?.listPRReviewCommentsAsync) {
+    return provider.listPRReviewCommentsAsync(repo, prNumber);
+  }
   try {
     const out = await ghQuietAsync(
       "api",
@@ -773,10 +857,19 @@ export async function listPRReviewCommentsAsync(repo: string, prNumber: number):
 }
 
 export async function addPRCommentAsync(repo: string, prNumber: number, body: string): Promise<void> {
+  const provider = activeProvider();
+  if (provider?.addPRCommentAsync) {
+    await provider.addPRCommentAsync(repo, prNumber, body);
+    return;
+  }
   await ghQuietAsync("pr", "comment", String(prNumber), "--repo", repo, "--body", body);
 }
 
 export function listPRFiles(repo: string, prNumber: number): PRChangedFile[] {
+  const provider = activeProvider();
+  if (provider?.listPRFiles) {
+    return provider.listPRFiles(repo, prNumber);
+  }
   try {
     const out = gh(
       "api",
@@ -793,6 +886,10 @@ export function listPRFiles(repo: string, prNumber: number): PRChangedFile[] {
 }
 
 export async function listPRFilesAsync(repo: string, prNumber: number): Promise<PRChangedFile[]> {
+  const provider = activeProvider();
+  if (provider?.listPRFilesAsync) {
+    return provider.listPRFilesAsync(repo, prNumber);
+  }
   try {
     const out = await ghQuietAsync(
       "api",
@@ -809,6 +906,15 @@ export async function listPRFilesAsync(repo: string, prNumber: number): Promise<
 }
 
 export function getCommitInfo(repo: string, branchRef: string, includeMessage: boolean = false): CommitInfo {
+  const provider = activeProvider();
+  if (provider?.getCommitInfo) {
+    const info = provider.getCommitInfo(repo, branchRef, includeMessage);
+    return {
+      message: info.message,
+      date: info.date,
+      authorLogin: info.authorLogin,
+    };
+  }
   const ref = encodeURIComponent(branchRef);
   const query = includeMessage
     ? `.commit.message + "${COMMIT_DELIM}" + .commit.author.date + "${COMMIT_DELIM}" + (.author.login // "")`
@@ -834,6 +940,15 @@ export function getCommitInfo(repo: string, branchRef: string, includeMessage: b
 }
 
 export async function getCommitInfoAsync(repo: string, branchRef: string, includeMessage: boolean = false): Promise<CommitInfo> {
+  const provider = activeProvider();
+  if (provider?.getCommitInfoAsync) {
+    const info = await provider.getCommitInfoAsync(repo, branchRef, includeMessage);
+    return {
+      message: info.message,
+      date: info.date,
+      authorLogin: info.authorLogin,
+    };
+  }
   const ref = encodeURIComponent(branchRef);
   const query = includeMessage
     ? `.commit.message + "${COMMIT_DELIM}" + .commit.author.date + "${COMMIT_DELIM}" + (.author.login // "")`

--- a/lib/mock-api-provider.ts
+++ b/lib/mock-api-provider.ts
@@ -1,0 +1,651 @@
+/**
+ * MockApiProvider — a fully stateful in-memory backend for copse.
+ *
+ * Every piece of state that a real GitHub/Cursor/filesystem interaction would
+ * touch is modelled here: repos, branches, PRs, workflow runs, review
+ * comments, Cursor agents, config, and templates. The state is plain data
+ * structures that tests can inspect, mutate, and reset cheaply.
+ */
+
+import type { ApiProvider } from "./api-provider.js";
+import type { PR, WorkflowRun, PRReviewComment, PRChangedFile } from "./types.js";
+import type { CommitInfo } from "./gh.js";
+import type { CursorAgent, CursorArtifact } from "./cursor-api.js";
+import type { Copserc } from "./config.js";
+
+export interface MockRepo {
+  defaultBranch: string;
+  allowSquashMerge?: boolean;
+  allowMergeCommit?: boolean;
+  allowRebaseMerge?: boolean;
+}
+
+export interface MockPR extends PR {
+  isDraft?: boolean;
+  mergeStateStatus?: string;
+  mergeable?: string;
+  reviewDecision?: string;
+  createdAt?: string;
+  updatedAt?: string;
+  autoMergeRequest?: unknown;
+  state?: "open" | "closed" | "merged";
+}
+
+export interface MockReviewThread {
+  id: string;
+  isResolved: boolean;
+  commentNodeIds: string[];
+}
+
+export class MockApiProvider implements ApiProvider {
+  currentUser = "test-user";
+  originRepo: string | null = null;
+  config: Copserc | null = null;
+  templates = new Map<string, Map<string, string>>();
+  repos = new Map<string, MockRepo>();
+  branches = new Map<string, string[]>();
+  prs = new Map<string, MockPR[]>();
+  workflowRuns = new Map<string, WorkflowRun[]>();
+  commits = new Map<string, CommitInfo>();
+  reviewComments = new Map<string, PRReviewComment[]>();
+  reviewThreads = new Map<string, MockReviewThread[]>();
+  prComments = new Map<string, string[]>();
+  prReplies = new Map<string, string[]>();
+  prFiles = new Map<string, PRChangedFile[]>();
+  cursorAgents = new Map<string, CursorAgent[]>();
+  cursorArtifacts = new Map<string, CursorArtifact[]>();
+  cursorDownloadUrls = new Map<string, { url: string; expiresAt?: string }>();
+  cursorFollowups = new Map<string, string[]>();
+  cursorLaunches = new Map<string, string[]>();
+  ghCalls: string[][] = [];
+  private _nextAgentId = 1;
+  private _nextPRNumber = 1;
+  private _nextIssueNumber = 1000;
+  private _nextCommentId = 5000;
+  statusCacheInvalidations = 0;
+
+  addRepo(repo: string, options: Partial<MockRepo> = {}): void {
+    this.repos.set(repo, {
+      defaultBranch: options.defaultBranch ?? "main",
+      allowSquashMerge: options.allowSquashMerge ?? true,
+      allowMergeCommit: options.allowMergeCommit ?? true,
+      allowRebaseMerge: options.allowRebaseMerge ?? true,
+    });
+    if (!this.branches.has(repo)) this.branches.set(repo, []);
+    if (!this.prs.has(repo)) this.prs.set(repo, []);
+  }
+
+  addBranch(repo: string, branchName: string, commitInfo?: Partial<CommitInfo>): void {
+    const existing = this.branches.get(repo) ?? [];
+    if (!existing.includes(branchName)) {
+      existing.push(branchName);
+      this.branches.set(repo, existing);
+    }
+    if (commitInfo || !this.commits.has(`${repo}:${branchName}`)) {
+      this.commits.set(`${repo}:${branchName}`, {
+        message: commitInfo?.message ?? `commit on ${branchName}`,
+        date: commitInfo?.date ?? new Date(),
+        authorLogin: commitInfo?.authorLogin ?? this.currentUser,
+      });
+    }
+  }
+
+  addPR(repo: string, pr: Partial<MockPR> & { headRefName: string }): MockPR {
+    const list = this.prs.get(repo) ?? [];
+    const number = pr.number ?? this._nextPRNumber++;
+    const now = new Date().toISOString();
+    const full: MockPR = {
+      number,
+      headRefName: pr.headRefName,
+      baseRefName: pr.baseRefName ?? this.repos.get(repo)?.defaultBranch ?? "main",
+      labels: pr.labels ?? [],
+      title: pr.title ?? `PR #${number}`,
+      author: pr.author ?? { login: this.currentUser },
+      isDraft: pr.isDraft ?? false,
+      mergeStateStatus: pr.mergeStateStatus ?? "CLEAN",
+      mergeable: pr.mergeable ?? "MERGEABLE",
+      reviewDecision: pr.reviewDecision ?? "APPROVED",
+      createdAt: pr.createdAt ?? now,
+      updatedAt: pr.updatedAt ?? now,
+      autoMergeRequest: pr.autoMergeRequest ?? null,
+      state: pr.state ?? "open",
+    };
+    list.push(full);
+    this.prs.set(repo, list);
+    this.addBranch(repo, pr.headRefName);
+    return full;
+  }
+
+  addWorkflowRun(repo: string, branch: string, run: Partial<WorkflowRun> & { name: string }): void {
+    const key = `${repo}:${branch}`;
+    const list = this.workflowRuns.get(key) ?? [];
+    list.push({
+      databaseId: run.databaseId ?? list.length + 1,
+      name: run.name,
+      conclusion: run.conclusion ?? "success",
+      status: run.status ?? "completed",
+      displayTitle: run.displayTitle ?? run.name,
+      attempt: run.attempt ?? 1,
+    });
+    this.workflowRuns.set(key, list);
+  }
+
+  addReviewComment(repo: string, prNumber: number, comment: Partial<PRReviewComment> & { body: string }): PRReviewComment {
+    const key = `${repo}:${prNumber}`;
+    const list = this.reviewComments.get(key) ?? [];
+    const id = comment.id ?? this._nextCommentId++;
+    const full: PRReviewComment = {
+      id,
+      node_id: comment.node_id ?? `MDI_${id}`,
+      body: comment.body,
+      path: comment.path ?? "file.ts",
+      line: comment.line ?? 1,
+      original_line: comment.original_line ?? 1,
+      diff_hunk: comment.diff_hunk ?? "@@ -1,3 +1,3 @@",
+      user: comment.user ?? { login: "reviewer" },
+      created_at: comment.created_at ?? new Date().toISOString(),
+      html_url: comment.html_url ?? `https://github.com/${repo}/pull/${prNumber}#discussion_r${id}`,
+      pull_request_url: comment.pull_request_url ?? `https://api.github.com/repos/${repo}/pulls/${prNumber}`,
+      in_reply_to_id: comment.in_reply_to_id,
+    };
+    list.push(full);
+    this.reviewComments.set(key, list);
+    return full;
+  }
+
+  addCursorAgent(prUrl: string, agent: Partial<CursorAgent> = {}): CursorAgent {
+    const list = this.cursorAgents.get(prUrl) ?? [];
+    const full: CursorAgent = {
+      id: agent.id ?? `agent-${this._nextAgentId++}`,
+      status: agent.status ?? "completed",
+      createdAt: agent.createdAt ?? new Date().toISOString(),
+      target: agent.target ?? { prUrl },
+    };
+    list.push(full);
+    this.cursorAgents.set(prUrl, list);
+    return full;
+  }
+
+  reset(): void {
+    this.currentUser = "test-user";
+    this.originRepo = null;
+    this.config = null;
+    this.templates.clear();
+    this.repos.clear();
+    this.branches.clear();
+    this.prs.clear();
+    this.workflowRuns.clear();
+    this.commits.clear();
+    this.reviewComments.clear();
+    this.reviewThreads.clear();
+    this.prComments.clear();
+    this.prReplies.clear();
+    this.prFiles.clear();
+    this.cursorAgents.clear();
+    this.cursorArtifacts.clear();
+    this.cursorDownloadUrls.clear();
+    this.cursorFollowups.clear();
+    this.cursorLaunches.clear();
+    this.ghCalls = [];
+    this._nextAgentId = 1;
+    this._nextPRNumber = 1;
+    this._nextIssueNumber = 1000;
+    this._nextCommentId = 5000;
+    this.statusCacheInvalidations = 0;
+  }
+
+  ensureGh(): void {}
+
+  getCurrentUser(): string {
+    return this.currentUser;
+  }
+
+  listOpenPRs(repo: string, _fields: string[] = []): PR[] {
+    return (this.prs.get(repo) ?? []).filter((pr) => (pr.state ?? "open") === "open");
+  }
+
+  async listOpenPRsAsync(repo: string, _fields: string[] = []): Promise<PR[]> {
+    return this.listOpenPRs(repo);
+  }
+
+  listBranches(repo: string): string[] {
+    return this.branches.get(repo) ?? [];
+  }
+
+  async listBranchesAsync(repo: string): Promise<string[]> {
+    return this.listBranches(repo);
+  }
+
+  async getDefaultBranchAsync(repo: string): Promise<string> {
+    const r = this.repos.get(repo);
+    if (!r) throw new Error(`Mock: unknown repo "${repo}"`);
+    return r.defaultBranch;
+  }
+
+  listWorkflowRuns(repo: string, branch: string): WorkflowRun[] {
+    return this.workflowRuns.get(`${repo}:${branch}`) ?? [];
+  }
+
+  async listWorkflowRunsAsync(repo: string, branch: string): Promise<WorkflowRun[]> {
+    return this.listWorkflowRuns(repo, branch);
+  }
+
+  getCommitInfo(repo: string, branchRef: string, includeMessage?: boolean): CommitInfo {
+    const info = this.commits.get(`${repo}:${branchRef}`);
+    if (!info) {
+      return {
+        message: includeMessage ? branchRef : undefined,
+        date: new Date(),
+        authorLogin: this.currentUser,
+      };
+    }
+    return includeMessage ? info : { date: info.date, authorLogin: info.authorLogin };
+  }
+
+  async getCommitInfoAsync(repo: string, branchRef: string, includeMessage?: boolean): Promise<CommitInfo> {
+    return this.getCommitInfo(repo, branchRef, includeMessage);
+  }
+
+  listPRReviewComments(repo: string, prNumber: number): PRReviewComment[] {
+    const all = this.reviewComments.get(`${repo}:${prNumber}`) ?? [];
+    const threads = this.reviewThreads.get(`${repo}:${prNumber}`) ?? [];
+    const resolvedNodeIds = new Set<string>();
+    for (const t of threads) {
+      if (t.isResolved) {
+        for (const id of t.commentNodeIds) resolvedNodeIds.add(id);
+      }
+    }
+    return all.filter((c) => !resolvedNodeIds.has(c.node_id));
+  }
+
+  async listPRReviewCommentsAsync(repo: string, prNumber: number): Promise<PRReviewComment[]> {
+    return this.listPRReviewComments(repo, prNumber);
+  }
+
+  getUnresolvedCommentCounts(repo: string, prNumbers: number[]): Map<number, number> {
+    const counts = new Map<number, number>();
+    for (const num of prNumbers) {
+      const comments = this.listPRReviewComments(repo, num);
+      counts.set(num, comments.length);
+    }
+    return counts;
+  }
+
+  async getUnresolvedCommentCountsAsync(repo: string, prNumbers: number[]): Promise<Map<number, number>> {
+    return this.getUnresolvedCommentCounts(repo, prNumbers);
+  }
+
+  async addPRCommentAsync(repo: string, prNumber: number, body: string): Promise<void> {
+    const key = `${repo}:${prNumber}`;
+    const list = this.prComments.get(key) ?? [];
+    list.push(body);
+    this.prComments.set(key, list);
+  }
+
+  async replyToPRCommentAsync(repo: string, prNumber: number, inReplyToId: number, body: string): Promise<void> {
+    const key = `${repo}:${prNumber}:${inReplyToId}`;
+    const list = this.prReplies.get(key) ?? [];
+    list.push(body);
+    this.prReplies.set(key, list);
+  }
+
+  listPRFiles(repo: string, prNumber: number): PRChangedFile[] {
+    return this.prFiles.get(`${repo}:${prNumber}`) ?? [];
+  }
+
+  async listPRFilesAsync(repo: string, prNumber: number): Promise<PRChangedFile[]> {
+    return this.listPRFiles(repo, prNumber);
+  }
+
+  gh(...args: string[]): string {
+    return this._handleGhCall(args);
+  }
+
+  ghQuiet(...args: string[]): string {
+    return this._handleGhCall(args);
+  }
+
+  async ghQuietAsync(...args: string[]): Promise<string> {
+    return this._handleGhCall(args);
+  }
+
+  private _handleGhCall(args: string[]): string {
+    this.ghCalls.push([...args]);
+
+    if (args[0] === "pr" && args[1] === "view") return this._handlePrView(args);
+    if (args[0] === "pr" && args[1] === "edit") return this._handlePrEdit(args);
+    if (args[0] === "pr" && args[1] === "merge") return this._handlePrMerge(args);
+    if (args[0] === "pr" && args[1] === "ready") return this._handlePrReady(args);
+    if (args[0] === "pr" && args[1] === "review") return this._handlePrReview(args);
+    if (args[0] === "pr" && args[1] === "close") return this._handlePrClose(args);
+    if (args[0] === "pr" && args[1] === "comment") return this._handlePrComment(args);
+    if (args[0] === "pr" && args[1] === "create") return this._handlePrCreate(args);
+    if (args[0] === "pr" && args[1] === "list") return this._handlePrList(args);
+    if (args[0] === "run" && args[1] === "list") return this._handleRunList(args);
+    if (args[0] === "run" && args[1] === "rerun") return this._handleRunRerun(args);
+    if (args[0] === "issue" && args[1] === "create") return this._handleIssueCreate(args);
+    if (args[0] === "issue" && args[1] === "comment") return "";
+    if (args[0] === "api" && args[1]?.startsWith("repos/")) return this._handleApiRepos(args);
+    if (args[0] === "api" && args[1] === "user") return JSON.stringify({ login: this.currentUser });
+    if (args[0] === "api" && args[1] === "graphql") return this._handleApiGraphql(args);
+
+    return "";
+  }
+
+  private _findFlag(args: string[], flag: string): string | null {
+    const idx = args.indexOf(flag);
+    return idx >= 0 && idx + 1 < args.length ? args[idx + 1] : null;
+  }
+
+  private _findRepo(args: string[]): string | null {
+    return this._findFlag(args, "--repo");
+  }
+
+  private _findPR(repo: string, prNumberStr: string): MockPR | undefined {
+    const num = parseInt(prNumberStr, 10);
+    return (this.prs.get(repo) ?? []).find((p) => p.number === num);
+  }
+
+  private _handlePrView(args: string[]): string {
+    const repo = this._findRepo(args) ?? "";
+    const prNumStr = args[2] ?? "";
+    const pr = this._findPR(repo, prNumStr);
+    if (!pr) return "";
+
+    const jsonFlag = this._findFlag(args, "--json");
+    const jqFlag = this._findFlag(args, "-q");
+    if (jsonFlag === "isDraft" && jqFlag === ".isDraft") return `${pr.isDraft ?? false}\n`;
+    if (jsonFlag === "baseRefName" && jqFlag === ".baseRefName") return `${pr.baseRefName ?? "main"}\n`;
+    return JSON.stringify(pr);
+  }
+
+  private _handlePrEdit(args: string[]): string {
+    const repo = this._findRepo(args) ?? "";
+    const prNumStr = args[2] ?? "";
+    const pr = this._findPR(repo, prNumStr);
+    if (!pr) throw this._ghError(`PR ${prNumStr} not found in ${repo}`);
+
+    const newBase = this._findFlag(args, "--base");
+    if (newBase) pr.baseRefName = newBase;
+    return "";
+  }
+
+  private _handlePrMerge(args: string[]): string {
+    const repo = this._findRepo(args) ?? "";
+    const prNumStr = args.find((a, i) => i >= 2 && /^\d+$/.test(a)) ?? "";
+    const pr = this._findPR(repo, prNumStr);
+    if (!pr) throw this._ghError(`PR ${prNumStr} not found in ${repo}`);
+    if (args.includes("--auto")) {
+      pr.autoMergeRequest = { enabledAt: new Date().toISOString() };
+    } else {
+      pr.state = "merged";
+    }
+    return "";
+  }
+
+  private _handlePrReady(args: string[]): string {
+    const repo = this._findRepo(args) ?? "";
+    const prNumStr = args[2] ?? "";
+    const pr = this._findPR(repo, prNumStr);
+    if (pr) pr.isDraft = false;
+    return "";
+  }
+
+  private _handlePrReview(args: string[]): string {
+    const repo = this._findRepo(args) ?? "";
+    const prNumStr = args.find((a, i) => i >= 2 && /^\d+$/.test(a)) ?? "";
+    const pr = this._findPR(repo, prNumStr);
+    if (pr && args.includes("--approve")) pr.reviewDecision = "APPROVED";
+    return "";
+  }
+
+  private _handlePrClose(args: string[]): string {
+    const repo = this._findRepo(args) ?? "";
+    const prNumStr = args[2] ?? "";
+    const pr = this._findPR(repo, prNumStr);
+    if (pr) pr.state = "closed";
+    return "";
+  }
+
+  private _handlePrComment(args: string[]): string {
+    const repo = this._findRepo(args) ?? "";
+    const prNumStr = args[2] ?? "";
+    const body = this._findFlag(args, "--body") ?? "";
+    const key = `${repo}:${prNumStr}`;
+    const list = this.prComments.get(key) ?? [];
+    list.push(body);
+    this.prComments.set(key, list);
+    return "";
+  }
+
+  private _handlePrCreate(args: string[]): string {
+    const repo = this._findRepo(args) ?? "";
+    const head = this._findFlag(args, "--head") ?? "";
+    const base = this._findFlag(args, "--base") ?? "main";
+    const title = this._findFlag(args, "--title") ?? head;
+    const body = this._findFlag(args, "--body");
+    const num = this._nextPRNumber++;
+    const pr: MockPR = {
+      number: num,
+      headRefName: head,
+      baseRefName: base,
+      labels: [],
+      title,
+      body: body ?? undefined,
+      author: { login: this.currentUser },
+      state: "open",
+    };
+    const list = this.prs.get(repo) ?? [];
+    list.push(pr);
+    this.prs.set(repo, list);
+    return `https://github.com/${repo}/pull/${num}\n`;
+  }
+
+  private _handlePrList(args: string[]): string {
+    const repo = this._findRepo(args) ?? "";
+    const openPRs = (this.prs.get(repo) ?? []).filter((p) => (p.state ?? "open") === "open");
+    return JSON.stringify(openPRs);
+  }
+
+  private _handleRunList(args: string[]): string {
+    const repo = this._findRepo(args) ?? "";
+    const branch = this._findFlag(args, "--branch") ?? "";
+    const runs = this.workflowRuns.get(`${repo}:${branch}`) ?? [];
+    return JSON.stringify(runs);
+  }
+
+  private _handleRunRerun(args: string[]): string {
+    const repo = this._findRepo(args) ?? "";
+    const runId = parseInt(args[2] ?? "", 10);
+    for (const [key, runs] of this.workflowRuns) {
+      if (!key.startsWith(`${repo}:`)) continue;
+      const run = runs.find((r) => r.databaseId === runId);
+      if (run) {
+        run.conclusion = "";
+        run.status = "queued";
+        break;
+      }
+    }
+    return "";
+  }
+
+  private _handleIssueCreate(args: string[]): string {
+    const repo = this._findRepo(args) ?? "";
+    const num = this._nextIssueNumber++;
+    return `https://github.com/${repo}/issues/${num}\n`;
+  }
+
+  private _handleApiRepos(args: string[]): string {
+    const path = args[1] ?? "";
+    const repoMatch = path.match(/^repos\/([^/]+\/[^/]+)$/);
+    if (repoMatch) {
+      const repo = repoMatch[1];
+      const r = this.repos.get(repo);
+      if (!r) return JSON.stringify({});
+
+      const jqFlag = this._findFlag(args, "-q");
+      if (jqFlag === ".default_branch") return `${r.defaultBranch}\n`;
+      if (jqFlag?.includes("allowSquashMerge")) {
+        return JSON.stringify({
+          allowSquashMerge: r.allowSquashMerge ?? true,
+          allowMergeCommit: r.allowMergeCommit ?? true,
+          allowRebaseMerge: r.allowRebaseMerge ?? true,
+        });
+      }
+      return JSON.stringify({
+        default_branch: r.defaultBranch,
+        allow_squash_merge: r.allowSquashMerge ?? true,
+        allow_merge_commit: r.allowMergeCommit ?? true,
+        allow_rebase_merge: r.allowRebaseMerge ?? true,
+      });
+    }
+
+    const branchesMatch = path.match(/^repos\/([^/]+\/[^/]+)\/branches$/);
+    if (branchesMatch) {
+      const repo = branchesMatch[1];
+      return `${(this.branches.get(repo) ?? []).join("\n")}\n`;
+    }
+
+    const commitMatch = path.match(/^repos\/([^/]+\/[^/]+)\/commits\/(.+)$/);
+    if (commitMatch) {
+      const repo = commitMatch[1];
+      const ref = decodeURIComponent(commitMatch[2]);
+      const info = this.commits.get(`${repo}:${ref}`);
+      if (info) {
+        return JSON.stringify({
+          commit: {
+            message: info.message ?? "",
+            author: { date: info.date?.toISOString() ?? "" },
+          },
+          author: { login: info.authorLogin },
+        });
+      }
+      return JSON.stringify({ commit: { message: "", author: { date: "" } }, author: { login: "" } });
+    }
+
+    const commentsMatch = path.match(/^repos\/([^/]+\/[^/]+)\/pulls\/(\d+)\/comments$/);
+    if (commentsMatch) {
+      const repo = commentsMatch[1];
+      const prNumber = parseInt(commentsMatch[2], 10);
+      return JSON.stringify(this.listPRReviewComments(repo, prNumber));
+    }
+
+    const filesMatch = path.match(/^repos\/([^/]+\/[^/]+)\/pulls\/(\d+)\/files$/);
+    if (filesMatch) {
+      const repo = filesMatch[1];
+      const prNumber = parseInt(filesMatch[2], 10);
+      return JSON.stringify(this.prFiles.get(`${repo}:${prNumber}`) ?? []);
+    }
+
+    const replyMatch = path.match(/^repos\/([^/]+\/[^/]+)\/pulls\/(\d+)\/comments\/(\d+)\/replies$/);
+    if (replyMatch) {
+      const repo = replyMatch[1];
+      const prNumber = parseInt(replyMatch[2], 10);
+      const inReplyToId = parseInt(replyMatch[3], 10);
+      const bodyRaw = this._findFlag(args, "-f") ?? "";
+      const body = bodyRaw.startsWith("body=") ? bodyRaw.slice("body=".length) : bodyRaw;
+      const key = `${repo}:${prNumber}:${inReplyToId}`;
+      const list = this.prReplies.get(key) ?? [];
+      list.push(body);
+      this.prReplies.set(key, list);
+      return "";
+    }
+
+    const mergesMatch = path.match(/^repos\/([^/]+\/[^/]+)\/merges$/);
+    if (mergesMatch) {
+      return JSON.stringify({ sha: "mock-merge-sha" });
+    }
+
+    return "";
+  }
+
+  private _handleApiGraphql(args: string[]): string {
+    const queryArg = args.find((a, i) => i > 0 && args[i - 1] === "-f" && a.startsWith("query="));
+    const query = queryArg?.slice("query=".length) ?? "";
+
+    if (query.includes("reviewThreads")) {
+      return JSON.stringify({
+        data: { repository: { pullRequest: { reviewThreads: { nodes: [] } } } },
+      });
+    }
+    if (query.includes("commits(last:") || query.includes("commits(last :")) {
+      return JSON.stringify({ data: { repository: {} } });
+    }
+
+    return JSON.stringify({ data: {} });
+  }
+
+  private _ghError(message: string): Error {
+    const err = new Error(message) as Error & { stderr?: string };
+    err.stderr = message;
+    return err;
+  }
+
+  async cursorListAgentsByPrUrl(_apiKey: string, prUrl: string): Promise<CursorAgent[]> {
+    return this.cursorAgents.get(prUrl) ?? [];
+  }
+
+  async cursorFindLatestAgentByPrUrl(_apiKey: string, prUrl: string): Promise<CursorAgent | null> {
+    const agents = this.cursorAgents.get(prUrl) ?? [];
+    if (agents.length === 0) return null;
+    const sorted = [...agents].sort((a, b) => {
+      const aTs = a.createdAt ? Date.parse(a.createdAt) : 0;
+      const bTs = b.createdAt ? Date.parse(b.createdAt) : 0;
+      return bTs - aTs;
+    });
+    return sorted[0] ?? null;
+  }
+
+  async cursorAddFollowup(_apiKey: string, agentId: string, text: string): Promise<string> {
+    const list = this.cursorFollowups.get(agentId) ?? [];
+    list.push(text);
+    this.cursorFollowups.set(agentId, list);
+    return agentId;
+  }
+
+  async cursorLaunchAgentForPrUrl(_apiKey: string, prUrl: string, text: string): Promise<string> {
+    const list = this.cursorLaunches.get(prUrl) ?? [];
+    list.push(text);
+    this.cursorLaunches.set(prUrl, list);
+    const id = `agent-${this._nextAgentId++}`;
+    const agent: CursorAgent = { id, status: "running", createdAt: new Date().toISOString(), target: { prUrl } };
+    const agents = this.cursorAgents.get(prUrl) ?? [];
+    agents.push(agent);
+    this.cursorAgents.set(prUrl, agents);
+    return id;
+  }
+
+  async cursorListAgentArtifacts(_apiKey: string, agentId: string): Promise<CursorArtifact[]> {
+    return this.cursorArtifacts.get(agentId) ?? [];
+  }
+
+  async cursorGetArtifactDownloadUrl(
+    _apiKey: string,
+    agentId: string,
+    absolutePath: string
+  ): Promise<{ url: string; expiresAt?: string }> {
+    const key = `${agentId}:${absolutePath}`;
+    return this.cursorDownloadUrls.get(key) ?? { url: `https://mock-download.test/${agentId}/${absolutePath}` };
+  }
+
+  loadConfig(_cwd?: string): Copserc | null {
+    return this.config;
+  }
+
+  getConfiguredRepos(_cwd?: string): string[] | null {
+    if (!this.config?.repos || this.config.repos.length === 0) return null;
+    return this.config.repos;
+  }
+
+  getOriginRepo(): string | null {
+    return this.originRepo;
+  }
+
+  loadTemplates(dirPath: string): Map<string, string> {
+    return this.templates.get(dirPath) ?? new Map();
+  }
+
+  invalidateStatusCache(): void {
+    this.statusCacheInvalidations++;
+  }
+}

--- a/lib/mock-mode.ts
+++ b/lib/mock-mode.ts
@@ -1,0 +1,156 @@
+import { getApiProvider, setApiProvider } from "./api-provider.js";
+import { MockApiProvider } from "./mock-api-provider.js";
+
+const MOCK_MODE_ENV_KEYS = ["COPSE_MOCK_MODE", "COPSE_USE_MOCK_PROVIDER"];
+
+let mockModeInitialized = false;
+
+function isTruthy(value: string | undefined): boolean {
+  if (!value) return false;
+  const normalized = value.trim().toLowerCase();
+  return normalized === "1" || normalized === "true" || normalized === "yes" || normalized === "on";
+}
+
+function isMockModeEnabled(): boolean {
+  return MOCK_MODE_ENV_KEYS.some((key) => isTruthy(process.env[key]));
+}
+
+function seedMockData(mock: MockApiProvider): void {
+  const repo = (process.env.COPSE_MOCK_REPO || "jonathanKingston/copse").trim();
+  const user = (process.env.COPSE_MOCK_USER || "mock-user").trim();
+
+  mock.currentUser = user;
+  mock.originRepo = repo;
+  mock.config = {
+    repos: [repo],
+    cursorApiKey: "cur_mock_api_key",
+  };
+
+  mock.addRepo(repo, {
+    defaultBranch: "main",
+    allowSquashMerge: true,
+    allowMergeCommit: true,
+    allowRebaseMerge: true,
+  });
+
+  mock.addBranch(repo, "claude/mockable-api-system-zwNmi", {
+    message: "Add mockable API system for testing TUI and web UIs without network access",
+    authorLogin: "claude",
+    date: new Date("2026-03-15T13:37:25Z"),
+  });
+  mock.addBranch(repo, "cursor/mock-mode-stack-a", {
+    message: "Mock mode stack A",
+    authorLogin: user,
+    date: new Date("2026-03-15T13:20:00Z"),
+  });
+  mock.addBranch(repo, "cursor/mock-mode-stack-b", {
+    message: "Mock mode stack B",
+    authorLogin: user,
+    date: new Date("2026-03-15T13:19:00Z"),
+  });
+
+  mock.addPR(repo, {
+    number: 201,
+    headRefName: "cursor/mock-mode-stack-a",
+    baseRefName: "main",
+    title: "Mock mode stack A",
+    author: { login: user },
+    isDraft: true,
+    reviewDecision: "REVIEW_REQUIRED",
+    mergeStateStatus: "CLEAN",
+    mergeable: "MERGEABLE",
+    createdAt: new Date("2026-03-15T13:20:00Z").toISOString(),
+    updatedAt: new Date("2026-03-15T13:20:00Z").toISOString(),
+  });
+  mock.addPR(repo, {
+    number: 202,
+    headRefName: "cursor/mock-mode-stack-b",
+    baseRefName: "main",
+    title: "Mock mode stack B",
+    author: { login: user },
+    isDraft: false,
+    reviewDecision: "APPROVED",
+    mergeStateStatus: "CLEAN",
+    mergeable: "MERGEABLE",
+    createdAt: new Date("2026-03-15T13:19:00Z").toISOString(),
+    updatedAt: new Date("2026-03-15T13:19:00Z").toISOString(),
+  });
+
+  mock.addWorkflowRun(repo, "cursor/mock-mode-stack-a", {
+    databaseId: 9001,
+    name: "CI",
+    conclusion: "failure",
+    status: "completed",
+    displayTitle: "CI",
+    attempt: 1,
+  });
+  mock.addWorkflowRun(repo, "cursor/mock-mode-stack-b", {
+    databaseId: 9002,
+    name: "CI",
+    conclusion: "success",
+    status: "completed",
+    displayTitle: "CI",
+    attempt: 1,
+  });
+
+  const comment = mock.addReviewComment(repo, 201, {
+    id: 8101,
+    node_id: "MDI_mock_comment_8101",
+    body: "Please add a persistence test for mock mode.",
+    path: "lib/mock-api-provider.ts",
+    line: 42,
+    original_line: 42,
+    user: { login: "reviewer-bot", type: "Bot" },
+  });
+  mock.reviewThreads.set(`${repo}:201`, [{
+    id: "thread-201-a",
+    isResolved: false,
+    commentNodeIds: [comment.node_id],
+  }]);
+
+  mock.prFiles.set(`${repo}:201`, [{
+    sha: "abc201",
+    filename: "lib/mock-api-provider.ts",
+    status: "modified",
+    additions: 24,
+    deletions: 3,
+    changes: 27,
+    patch: "@@ -1,2 +1,3 @@\n+mock mode wiring",
+  }]);
+  mock.prFiles.set(`${repo}:202`, [{
+    sha: "abc202",
+    filename: "web/server.ts",
+    status: "modified",
+    additions: 10,
+    deletions: 2,
+    changes: 12,
+    patch: "@@ -10,2 +10,3 @@\n+provider delegation",
+  }]);
+
+  const prUrl = `https://github.com/${repo}/pull/201`;
+  const agent = mock.addCursorAgent(prUrl, {
+    id: "agent-mock-201",
+    status: "completed",
+    createdAt: new Date("2026-03-15T13:22:00Z").toISOString(),
+    target: { prUrl },
+  });
+  mock.cursorArtifacts.set(agent.id, [{
+    absolutePath: "/opt/cursor/artifacts/mock_mode_validation.log",
+    sizeBytes: 2048,
+    updatedAt: new Date("2026-03-15T13:23:00Z").toISOString(),
+  }]);
+
+  mock.templates.set("/mock/templates", new Map([
+    ["please-fix", "Please fix this in mock mode."],
+  ]));
+}
+
+export function ensureMockProviderConfigured(): void {
+  if (mockModeInitialized) return;
+  mockModeInitialized = true;
+  if (!isMockModeEnabled()) return;
+  if (getApiProvider()) return;
+  const mock = new MockApiProvider();
+  seedMockData(mock);
+  setApiProvider(mock);
+}

--- a/lib/runtime-init.ts
+++ b/lib/runtime-init.ts
@@ -1,0 +1,9 @@
+import { ensureMockProviderConfigured } from "./mock-mode.js";
+
+let runtimeInitialized = false;
+
+export function initializeRuntime(): void {
+  if (runtimeInitialized) return;
+  runtimeInitialized = true;
+  ensureMockProviderConfigured();
+}

--- a/lib/services/status-service.ts
+++ b/lib/services/status-service.ts
@@ -31,7 +31,6 @@ import {
   isPRWithStatus,
 } from "./status-types.js";
 import { getApiProvider } from "../api-provider.js";
-import { ensureMockProviderConfigured } from "../mock-mode.js";
 
 export interface StatusQueryOptions {
   repos: string[];
@@ -51,7 +50,6 @@ const statusCache = new Map<string, CacheEntry>();
 const inflightRequests = new Map<string, Promise<StatusRow[]>>();
 const STATUS_CACHE_DIR = join(tmpdir(), "copse", "status-cache");
 let diskCacheDirPromise: Promise<string | null> | null = null;
-ensureMockProviderConfigured();
 
 function cacheKey(options: StatusQueryOptions): string {
   return `${[...options.repos].sort().join(",")}\0${options.scope}`;

--- a/lib/services/status-service.ts
+++ b/lib/services/status-service.ts
@@ -30,6 +30,8 @@ import {
   type StatusFilterScope,
   isPRWithStatus,
 } from "./status-types.js";
+import { getApiProvider } from "../api-provider.js";
+import { ensureMockProviderConfigured } from "../mock-mode.js";
 
 export interface StatusQueryOptions {
   repos: string[];
@@ -49,6 +51,7 @@ const statusCache = new Map<string, CacheEntry>();
 const inflightRequests = new Map<string, Promise<StatusRow[]>>();
 const STATUS_CACHE_DIR = join(tmpdir(), "copse", "status-cache");
 let diskCacheDirPromise: Promise<string | null> | null = null;
+ensureMockProviderConfigured();
 
 function cacheKey(options: StatusQueryOptions): string {
   return `${[...options.repos].sort().join(",")}\0${options.scope}`;
@@ -57,6 +60,7 @@ function cacheKey(options: StatusQueryOptions): string {
 export function invalidateStatusCache(): void {
   statusCache.clear();
   inflightRequests.clear();
+  getApiProvider()?.invalidateStatusCache?.();
   void clearDiskStatusCache();
 }
 

--- a/lib/templates.ts
+++ b/lib/templates.ts
@@ -6,8 +6,12 @@
 import { readdirSync, readFileSync, mkdirSync, writeFileSync, existsSync } from "fs";
 import { join } from "path";
 import { homedir } from "os";
+import { getApiProvider } from "./api-provider.js";
+import { ensureMockProviderConfigured } from "./mock-mode.js";
 
 const DEFAULT_TEMPLATES_DIR = ".copse/comment-templates";
+
+ensureMockProviderConfigured();
 
 const STARTER_TEMPLATES: Record<string, string> = {
   "please-fix.md": "Please fix this.",
@@ -42,6 +46,10 @@ export function scaffoldTemplates(dirPath: string): void {
  * Does NOT prompt or scaffold—caller handles that.
  */
 export function loadTemplates(dirPath: string): Map<string, string> {
+  const provider = getApiProvider();
+  if (provider?.loadTemplates) {
+    return provider.loadTemplates(dirPath);
+  }
   const resolved = expandTildePath(dirPath);
   if (!existsSync(resolved)) {
     return new Map();

--- a/lib/templates.ts
+++ b/lib/templates.ts
@@ -7,11 +7,8 @@ import { readdirSync, readFileSync, mkdirSync, writeFileSync, existsSync } from 
 import { join } from "path";
 import { homedir } from "os";
 import { getApiProvider } from "./api-provider.js";
-import { ensureMockProviderConfigured } from "./mock-mode.js";
 
 const DEFAULT_TEMPLATES_DIR = ".copse/comment-templates";
-
-ensureMockProviderConfigured();
 
 const STARTER_TEMPLATES: Record<string, string> = {
   "please-fix.md": "Please fix this.",

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,5 +1,9 @@
 import { execSync } from "child_process";
 import type { PRReviewComment } from "./types.js";
+import { getApiProvider } from "./api-provider.js";
+import { ensureMockProviderConfigured } from "./mock-mode.js";
+
+ensureMockProviderConfigured();
 
 /** True if the comment was posted by a bot/automated account. */
 export function isBotComment(comment: PRReviewComment): boolean {
@@ -10,6 +14,10 @@ export function isBotComment(comment: PRReviewComment): boolean {
 }
 
 export function getOriginRepo(): string | null {
+  const provider = getApiProvider();
+  if (provider?.getOriginRepo) {
+    return provider.getOriginRepo();
+  }
   try {
     const url = execSync("git remote get-url origin", {
       encoding: "utf-8",

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,9 +1,6 @@
 import { execSync } from "child_process";
 import type { PRReviewComment } from "./types.js";
 import { getApiProvider } from "./api-provider.js";
-import { ensureMockProviderConfigured } from "./mock-mode.js";
-
-ensureMockProviderConfigured();
 
 /** True if the comment was posted by a bot/automated account. */
 export function isBotComment(comment: PRReviewComment): boolean {

--- a/tests/mock-mode-wiring.test.ts
+++ b/tests/mock-mode-wiring.test.ts
@@ -1,0 +1,62 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { setApiProvider, resetApiProvider } from "../lib/api-provider.js";
+import { MockApiProvider } from "../lib/mock-api-provider.js";
+import { fetchPRsWithStatus, invalidateStatusCache } from "../lib/services/status-service.js";
+import { markPullRequestReady, retargetPullRequest, enableMergeWhenReady, rerunFailedWorkflowRuns } from "../lib/services/status-actions.js";
+import { getCurrentUser } from "../lib/gh.js";
+
+test("status + actions run through mock provider", async () => {
+  const repo = "acme/mock-provider";
+  const mock = new MockApiProvider();
+  mock.currentUser = "alice";
+  mock.originRepo = repo;
+  mock.config = { repos: [repo], cursorApiKey: "cur_mock" };
+  mock.addRepo(repo, { defaultBranch: "main" });
+  mock.addBranch(repo, "cursor/stack-a", { message: "A", authorLogin: "alice" });
+  mock.addPR(repo, {
+    number: 1,
+    headRefName: "cursor/stack-a",
+    baseRefName: "main",
+    title: "Stack A",
+    isDraft: true,
+    reviewDecision: "REVIEW_REQUIRED",
+  });
+  mock.addWorkflowRun(repo, "cursor/stack-a", {
+    databaseId: 42,
+    name: "CI",
+    conclusion: "failure",
+    status: "completed",
+    displayTitle: "CI",
+  });
+
+  setApiProvider(mock);
+  invalidateStatusCache();
+  try {
+    assert.equal(getCurrentUser(), "alice");
+
+    const rows = await fetchPRsWithStatus({ repos: [repo], scope: "all" });
+    const prRow = rows.find((row) => row.rowType === "pr" && row.repo === repo && row.number === 1);
+    assert.ok(prRow);
+    assert.equal(prRow.ciStatus, "fail");
+
+    const ready = await markPullRequestReady(repo, 1);
+    assert.equal(ready.markedReady, true);
+    assert.equal(mock.prs.get(repo)?.[0].isDraft, false);
+
+    const retarget = await retargetPullRequest(repo, 1, "main");
+    assert.equal(retarget.alreadyTargeted, true);
+
+    const merge = await enableMergeWhenReady(repo, 1);
+    assert.equal(merge.enabled, true);
+    assert.ok(mock.prs.get(repo)?.[0].autoMergeRequest);
+
+    const rerun = await rerunFailedWorkflowRuns(repo, "cursor/stack-a");
+    assert.equal(rerun.total, 1);
+    assert.equal(mock.workflowRuns.get(`${repo}:cursor/stack-a`)?.[0].status, "queued");
+    assert.equal(mock.workflowRuns.get(`${repo}:cursor/stack-a`)?.[0].conclusion, "");
+  } finally {
+    resetApiProvider();
+    invalidateStatusCache();
+  }
+});

--- a/web/server.ts
+++ b/web/server.ts
@@ -2,6 +2,7 @@ import { createServer, type IncomingMessage, type ServerResponse } from "node:ht
 import { readFile } from "node:fs/promises";
 import { extname, join, resolve } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
+import { initializeRuntime } from "../lib/runtime-init.js";
 import { getConfiguredRepos, loadConfig } from "../lib/config.js";
 import { REPO_PATTERN, listPRReviewCommentsAsync, listPRFilesAsync, validateRepo } from "../lib/gh.js";
 import { getOriginRepo } from "../lib/utils.js";
@@ -27,6 +28,8 @@ import {
 import { findLatestAgentByPrUrl, getArtifactDownloadUrl, listAgentArtifacts, listAgentsByPrUrl } from "../lib/cursor-api.js";
 import { sendReplyViaCursorApi } from "../lib/cursor-replies.js";
 import { loadTemplates, resolveTemplatesPath } from "../lib/templates.js";
+
+initializeRuntime();
 
 const DEFAULT_HOST = "127.0.0.1";
 const DEFAULT_PORT = 4317;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- decouple mock bootstrapping from low-level library modules (`gh`, Cursor API, config, templates, utils, status service)
- add a runtime initializer (`lib/runtime-init.ts`) that performs one-time mock provider bootstrap
- initialize runtime only at process entrypoints (`copse.ts`, all `commands/*.ts`, and `web/server.ts`) so child command processes keep mock mode behavior without adapter-layer coupling

## Validation
- build passes: `npm run build`
- mock wiring integration test passes: `node --test "dist/tests/mock-mode-wiring.test.js"`
- status/web regressions pass: `node --test "dist/tests/status-actions.test.js" "dist/tests/status-service.test.js" "dist/tests/web-server.test.js"`
- manual mock-mode checks after cleanup:
  - TUI: `copse status` + `r` rerun updates CI from failed to pending in-session
  - Web UI: `copse web` Ready action persists across refresh and second Ready returns "already ready"

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2a44a7f8-4a48-404e-9a22-490c6dc56e32"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2a44a7f8-4a48-404e-9a22-490c6dc56e32"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

