### PR TITLE
Reduce GitHub API usage to avoid rate limits

### DIFF
--- a/commands/create-prs.ts
+++ b/commands/create-prs.ts
@@ -16,7 +16,7 @@ import { readFileSync } from "fs";
 import { resolve } from "path";
 import { initializeRuntime } from "../lib/runtime-init.js";
 import {
-  validateRepo, validateAgent, gh, getCommitInfo, AGENT_BRANCH_PATTERNS, listBranches,
+  validateRepo, validateAgent, gh, getCommitInfoBatch, AGENT_BRANCH_PATTERNS, listBranches,
 } from "../lib/gh.js";
 import { parseStandardFlags, parseHoursOption, parseBaseOption, parseTemplateOption, calculateSinceDate } from "../lib/args.js";
 import { getUserForDisplay } from "../lib/filters.js";
@@ -174,28 +174,37 @@ Examples:
   console.error(`Fetching open PR head branches...`);
   const prHeads = new Set(listOpenPRHeadBranches(repo));
 
-  const withCommits: { branch: string; message: string }[] = [];
-  for (const branch of agentBranches) {
+  // Filter out branches that already have PRs before fetching commit info.
+  const candidateBranches = agentBranches.filter((branch) => {
     if (prHeads.has(branch)) {
       console.error(`  Skipping ${branch} (PR already exists)`);
+      return false;
+    }
+    return true;
+  });
+
+  // Batch-fetch commit info for all candidate branches in a single GraphQL query.
+  const commitInfoMap = getCommitInfoBatch(repo, candidateBranches, true);
+
+  const withCommits: { branch: string; message: string }[] = [];
+  for (const branch of candidateBranches) {
+    const info = commitInfoMap.get(branch);
+    if (!info) {
+      console.error(`  Skipping ${branch}: could not fetch commit info`);
       continue;
     }
-    try {
-      const { message, date, authorLogin } = getCommitInfo(repo, branch, true);
-      if (date && date < since) {
-        console.error(`  Skipping ${branch} (last commit ${date.toISOString()} outside --hours ${hours})`);
+    const { message, date, authorLogin } = info;
+    if (date && date < since) {
+      console.error(`  Skipping ${branch} (last commit ${date.toISOString()} outside --hours ${hours})`);
+      continue;
+    }
+    if (mineOnly) {
+      if (authorLogin !== currentUser) {
+        console.error(`  Skipping ${branch} (latest commit by @${authorLogin || "unknown"}, not you)`);
         continue;
       }
-      if (mineOnly) {
-        if (authorLogin !== currentUser) {
-          console.error(`  Skipping ${branch} (latest commit by @${authorLogin || "unknown"}, not you)`);
-          continue;
-        }
-      }
-      withCommits.push({ branch, message: message! });
-    } catch (e: unknown) {
-      console.error(`  Skipping ${branch}: ${(e as Error).message}`);
     }
+    withCommits.push({ branch, message: message! });
   }
 
   if (withCommits.length === 0) {

--- a/commands/rerun-failed.ts
+++ b/commands/rerun-failed.ts
@@ -10,7 +10,7 @@ import { initializeRuntime } from "../lib/runtime-init.js";
 import { getOriginRepo } from "../lib/utils.js";
 import type { WorkflowRun } from "../lib/types.js";
 import {
-  REPO_PATTERN, validateRepo, validateAgent, gh, getCommitInfo, AGENT_BRANCH_PATTERNS, listBranches,
+  REPO_PATTERN, validateRepo, validateAgent, gh, getCommitInfoBatch, AGENT_BRANCH_PATTERNS, listBranches,
 } from "../lib/gh.js";
 import { parseStandardFlags, parseHoursOption, calculateSinceDate } from "../lib/args.js";
 import { getUserForDisplay } from "../lib/filters.js";
@@ -24,7 +24,7 @@ function listFailedRuns(repo: string, branch: string): WorkflowRun[] {
       "--repo", repo,
       "--branch", branch,
       "--status", "failure",
-      "--limit", "50",
+      "--limit", "20",
       "--json", "databaseId,name,conclusion"
     );
     const runs = JSON.parse(out || "[]");
@@ -126,21 +126,22 @@ Examples:
     process.exit(0);
   }
 
+  // Batch-fetch commit info for all agent branches in a single GraphQL query.
+  const commitInfoMap = getCommitInfoBatch(repo, agentBranches, false);
+
   const recentBranches: string[] = [];
   for (const branch of agentBranches) {
-    try {
-      const { date, authorLogin } = getCommitInfo(repo, branch);
-      if (!date || date < since) continue;
-      if (mineOnly) {
-        if (authorLogin !== currentUser) {
-          console.error(`  Skipping ${branch} (latest commit by @${authorLogin || "unknown"}, not you)`);
-          continue;
-        }
+    const info = commitInfoMap.get(branch);
+    if (!info) continue;
+    const { date, authorLogin } = info;
+    if (!date || date < since) continue;
+    if (mineOnly) {
+      if (authorLogin !== currentUser) {
+        console.error(`  Skipping ${branch} (latest commit by @${authorLogin || "unknown"}, not you)`);
+        continue;
       }
-      recentBranches.push(branch);
-    } catch (e: unknown) {
-      console.error(`  Skipping ${branch}: ${(e as Error).message}`);
     }
+    recentBranches.push(branch);
   }
 
   if (recentBranches.length === 0) {

--- a/commands/status.ts
+++ b/commands/status.ts
@@ -43,7 +43,8 @@ import {
   postPullRequestReply,
   rerunFailedWorkflowRuns,
 } from "../lib/services/status-actions.js";
-import { STALE_DAYS, WATCH_INTERVAL_MS, type PRWithStatus, isPRWithStatus } from "../lib/services/status-types.js";
+import { STALE_DAYS, type PRWithStatus, isPRWithStatus } from "../lib/services/status-types.js";
+import { getWatchIntervalMs } from "../lib/config.js";
 import {
   loadTemplates,
   scaffoldTemplates,
@@ -1764,12 +1765,13 @@ function runWatch(
 
   refresh();
 
+  const pollMs = getWatchIntervalMs();
   function loop(): void {
     if (isInterrupted()) { cleanup(); return; }
     if (!busy && !ciUpdatePending) refresh();
-    setTimeout(loop, WATCH_INTERVAL_MS);
+    setTimeout(loop, pollMs);
   }
-  setTimeout(loop, WATCH_INTERVAL_MS);
+  setTimeout(loop, pollMs);
 }
 
 async function main(): Promise<void> {

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -17,6 +17,9 @@ export interface Copserc {
   repos?: string[];
   commentTemplates?: string;
   cursorApiKey?: string;
+  /** Poll interval in milliseconds for the TUI/web dashboard refresh cycle.
+   *  Higher values reduce GitHub API usage. Default: 60000 (60s). */
+  pollIntervalMs?: number;
 }
 
 function findConfigDir(startDir: string): string | null {
@@ -46,8 +49,10 @@ function loadConfigFromPath(configPath: string): Copserc | null {
       !("commentTemplates" in config) || typeof config.commentTemplates === "string";
     const hasCursorApiKey =
       !("cursorApiKey" in config) || typeof config.cursorApiKey === "string";
+    const hasPollInterval =
+      !("pollIntervalMs" in config) || typeof config.pollIntervalMs === "number";
 
-    if (hasRepos && hasCommentTemplates && hasCursorApiKey) {
+    if (hasRepos && hasCommentTemplates && hasCursorApiKey && hasPollInterval) {
       return config;
     }
   } catch {
@@ -69,6 +74,24 @@ export function loadConfig(cwd: string = process.cwd()): Copserc | null {
   if (!configDir) return null;
 
   return loadConfigFromPath(join(configDir, CONFIG_FILENAME));
+}
+
+const DEFAULT_POLL_INTERVAL_MS = 60_000;
+const MIN_POLL_INTERVAL_MS = 10_000;
+
+let _cachedPollInterval: number | null = null;
+
+/** Returns the poll interval in ms from .copserc `pollIntervalMs`, or 60s default.
+ *  Minimum is 10s to avoid hammering the API. */
+export function getWatchIntervalMs(): number {
+  if (_cachedPollInterval !== null) return _cachedPollInterval;
+  const config = loadConfig();
+  if (config?.pollIntervalMs && config.pollIntervalMs >= MIN_POLL_INTERVAL_MS) {
+    _cachedPollInterval = config.pollIntervalMs;
+  } else {
+    _cachedPollInterval = DEFAULT_POLL_INTERVAL_MS;
+  }
+  return _cachedPollInterval;
 }
 
 export function getConfiguredRepos(cwd: string = process.cwd()): string[] | null {

--- a/lib/gh.ts
+++ b/lib/gh.ts
@@ -23,8 +23,8 @@ const GH_TIMEOUT_MS = 30_000;
 const MAX_RETRIES = 3;
 const RETRY_BASE_MS = 1_000;
 const GRAPHQL_CHUNK_SIZE = 20;
-// Scan a generous commit window so agent co-author matches survive follow-up human commits.
-const COAUTHOR_SCAN_COMMIT_COUNT = 100;
+// Scan recent commits for agent co-author matches.
+const COAUTHOR_SCAN_COMMIT_COUNT = 30;
 
 let _interrupted = false;
 let _pipeStdio = false;
@@ -471,7 +471,7 @@ export function listWorkflowRuns(repo: string, branch: string): WorkflowRun[] {
       "run", "list",
       "--repo", repo,
       "--branch", branch,
-      "--limit", "100",
+      "--limit", "25",
       "--json", "databaseId,name,conclusion,attempt,status,displayTitle"
     );
     const runs = JSON.parse(out || "[]");
@@ -491,7 +491,7 @@ export async function listWorkflowRunsAsync(repo: string, branch: string): Promi
       "run", "list",
       "--repo", repo,
       "--branch", branch,
-      "--limit", "100",
+      "--limit", "25",
       "--json", "databaseId,name,conclusion,attempt,status,displayTitle"
     );
     const runs = JSON.parse(out || "[]");
@@ -501,13 +501,30 @@ export async function listWorkflowRunsAsync(repo: string, branch: string): Promi
   }
 }
 
+const AGENT_BRANCH_PREFIXES = ["cursor/", "claude/", "copilot/"];
+
+function extractBranchNames(out: string): string[] {
+  if (!out.trim()) return [];
+  return out.trim().split("\n").filter(Boolean);
+}
+
 export function listBranches(repo: string): string[] {
   const provider = activeProvider();
   if (provider?.listBranches) {
     return provider.listBranches(repo);
   }
-  const out = gh("api", `repos/${repo}/branches`, "--paginate", "-q", ".[].name");
-  return out.trim() ? out.trim().split("\n") : [];
+  const results: string[] = [];
+  for (const prefix of AGENT_BRANCH_PREFIXES) {
+    try {
+      const out = gh(
+        "api", `repos/${repo}/git/matching-refs/heads/${prefix}`,
+        "--paginate",
+        "-q", '.[].ref | sub("^refs/heads/"; "")',
+      );
+      results.push(...extractBranchNames(out));
+    } catch { /* skip prefix */ }
+  }
+  return results;
 }
 
 export async function listBranchesAsync(repo: string): Promise<string[]> {
@@ -515,8 +532,21 @@ export async function listBranchesAsync(repo: string): Promise<string[]> {
   if (provider?.listBranchesAsync) {
     return provider.listBranchesAsync(repo);
   }
-  const out = await ghQuietAsync("api", `repos/${repo}/branches`, "--paginate", "-q", ".[].name");
-  return out.trim() ? out.trim().split("\n") : [];
+  const results = await Promise.all(
+    AGENT_BRANCH_PREFIXES.map(async (prefix) => {
+      try {
+        const out = await ghQuietAsync(
+          "api", `repos/${repo}/git/matching-refs/heads/${prefix}`,
+          "--paginate",
+          "-q", '.[].ref | sub("^refs/heads/"; "")',
+        );
+        return extractBranchNames(out);
+      } catch {
+        return [];
+      }
+    })
+  );
+  return results.flat();
 }
 
 export function getDefaultBranch(repo: string): string {
@@ -633,6 +663,132 @@ export interface CommitInfo {
   message?: string;
   date: Date | null;
   authorLogin: string;
+}
+
+/** Fetch commit info for multiple branches in a single GraphQL query (batched). */
+export function getCommitInfoBatch(
+  repo: string,
+  branches: string[],
+  includeMessage: boolean = false
+): Map<string, CommitInfo> {
+  if (branches.length === 0) return new Map();
+  const provider = activeProvider();
+  if (provider?.getCommitInfo) {
+    const result = new Map<string, CommitInfo>();
+    for (const branch of branches) {
+      try {
+        const info = provider.getCommitInfo(repo, branch, includeMessage);
+        result.set(branch, { message: info.message, date: info.date, authorLogin: info.authorLogin });
+      } catch { /* skip branch */ }
+    }
+    return result;
+  }
+  const [owner, name] = repo.split("/");
+  const result = new Map<string, CommitInfo>();
+
+  for (let i = 0; i < branches.length; i += GRAPHQL_CHUNK_SIZE) {
+    const chunk = branches.slice(i, i + GRAPHQL_CHUNK_SIZE);
+    const fragments = chunk.map((branch, idx) => {
+      const qualifiedName = `refs/heads/${branch}`;
+      return `b${i + idx}: ref(qualifiedName: ${JSON.stringify(qualifiedName)}) {
+        target { ... on Commit { message committedDate author { user { login } } } }
+      }`;
+    });
+
+    const query = `query($owner: String!, $name: String!) {
+      repository(owner: $owner, name: $name) {
+        ${fragments.join("\n        ")}
+      }
+    }`;
+
+    try {
+      const out = gh(
+        "api", "graphql",
+        "-f", `query=${query}`,
+        "-f", `owner=${owner}`,
+        "-f", `name=${name}`,
+      );
+      const repoData = (JSON.parse(out) as { data: { repository: Record<string, unknown> } })
+        .data?.repository ?? {};
+
+      for (let j = 0; j < chunk.length; j++) {
+        const refData = repoData[`b${i + j}`] as {
+          target?: { message?: string; committedDate?: string; author?: { user?: { login?: string } } };
+        } | null;
+        if (!refData?.target) continue;
+        const t = refData.target;
+        result.set(chunk[j], {
+          message: includeMessage ? (t.message || "").trim() : undefined,
+          date: t.committedDate ? new Date(t.committedDate) : null,
+          authorLogin: t.author?.user?.login || "",
+        });
+      }
+    } catch { /* skip chunk */ }
+  }
+  return result;
+}
+
+/** Async variant of getCommitInfoBatch. */
+export async function getCommitInfoBatchAsync(
+  repo: string,
+  branches: string[],
+  includeMessage: boolean = false
+): Promise<Map<string, CommitInfo>> {
+  if (branches.length === 0) return new Map();
+  const provider = activeProvider();
+  if (provider?.getCommitInfoAsync) {
+    const result = new Map<string, CommitInfo>();
+    for (const branch of branches) {
+      try {
+        const info = await provider.getCommitInfoAsync(repo, branch, includeMessage);
+        result.set(branch, { message: info.message, date: info.date, authorLogin: info.authorLogin });
+      } catch { /* skip branch */ }
+    }
+    return result;
+  }
+  const [owner, name] = repo.split("/");
+  const result = new Map<string, CommitInfo>();
+
+  for (let i = 0; i < branches.length; i += GRAPHQL_CHUNK_SIZE) {
+    const chunk = branches.slice(i, i + GRAPHQL_CHUNK_SIZE);
+    const fragments = chunk.map((branch, idx) => {
+      const qualifiedName = `refs/heads/${branch}`;
+      return `b${i + idx}: ref(qualifiedName: ${JSON.stringify(qualifiedName)}) {
+        target { ... on Commit { message committedDate author { user { login } } } }
+      }`;
+    });
+
+    const query = `query($owner: String!, $name: String!) {
+      repository(owner: $owner, name: $name) {
+        ${fragments.join("\n        ")}
+      }
+    }`;
+
+    try {
+      const out = await ghQuietAsync(
+        "api", "graphql",
+        "-f", `query=${query}`,
+        "-f", `owner=${owner}`,
+        "-f", `name=${name}`,
+      );
+      const repoData = (JSON.parse(out) as { data: { repository: Record<string, unknown> } })
+        .data?.repository ?? {};
+
+      for (let j = 0; j < chunk.length; j++) {
+        const refData = repoData[`b${i + j}`] as {
+          target?: { message?: string; committedDate?: string; author?: { user?: { login?: string } } };
+        } | null;
+        if (!refData?.target) continue;
+        const t = refData.target;
+        result.set(chunk[j], {
+          message: includeMessage ? (t.message || "").trim() : undefined,
+          date: t.committedDate ? new Date(t.committedDate) : null,
+          authorLogin: t.author?.user?.login || "",
+        });
+      }
+    } catch { /* skip chunk */ }
+  }
+  return result;
 }
 
 export function getResolvedCommentNodeIds(repo: string, prNumber: number): Set<string> {

--- a/lib/gh.ts
+++ b/lib/gh.ts
@@ -501,30 +501,13 @@ export async function listWorkflowRunsAsync(repo: string, branch: string): Promi
   }
 }
 
-const AGENT_BRANCH_PREFIXES = ["cursor/", "claude/", "copilot/"];
-
-function extractBranchNames(out: string): string[] {
-  if (!out.trim()) return [];
-  return out.trim().split("\n").filter(Boolean);
-}
-
 export function listBranches(repo: string): string[] {
   const provider = activeProvider();
   if (provider?.listBranches) {
     return provider.listBranches(repo);
   }
-  const results: string[] = [];
-  for (const prefix of AGENT_BRANCH_PREFIXES) {
-    try {
-      const out = gh(
-        "api", `repos/${repo}/git/matching-refs/heads/${prefix}`,
-        "--paginate",
-        "-q", '.[].ref | sub("^refs/heads/"; "")',
-      );
-      results.push(...extractBranchNames(out));
-    } catch { /* skip prefix */ }
-  }
-  return results;
+  const out = gh("api", `repos/${repo}/branches`, "--paginate", "-q", ".[].name");
+  return out.trim() ? out.trim().split("\n") : [];
 }
 
 export async function listBranchesAsync(repo: string): Promise<string[]> {
@@ -532,21 +515,8 @@ export async function listBranchesAsync(repo: string): Promise<string[]> {
   if (provider?.listBranchesAsync) {
     return provider.listBranchesAsync(repo);
   }
-  const results = await Promise.all(
-    AGENT_BRANCH_PREFIXES.map(async (prefix) => {
-      try {
-        const out = await ghQuietAsync(
-          "api", `repos/${repo}/git/matching-refs/heads/${prefix}`,
-          "--paginate",
-          "-q", '.[].ref | sub("^refs/heads/"; "")',
-        );
-        return extractBranchNames(out);
-      } catch {
-        return [];
-      }
-    })
-  );
-  return results.flat();
+  const out = await ghQuietAsync("api", `repos/${repo}/branches`, "--paginate", "-q", ".[].name");
+  return out.trim() ? out.trim().split("\n") : [];
 }
 
 export function getDefaultBranch(repo: string): string {

--- a/lib/services/status-actions.ts
+++ b/lib/services/status-actions.ts
@@ -111,7 +111,7 @@ export async function rerunFailedWorkflowRuns(repo: string, headRefName: string)
     "run", "list",
     "--repo", repo,
     "--branch", headRefName,
-    "--limit", "100",
+    "--limit", "25",
     "--json", "databaseId,name,conclusion,attempt,status,displayTitle"
   );
   const runs = JSON.parse(runsJson || "[]") as WorkflowRun[];

--- a/lib/services/status-service.ts
+++ b/lib/services/status-service.ts
@@ -8,6 +8,8 @@ import {
   getCurrentUser,
   getCommitInfo,
   getCommitInfoAsync,
+  getCommitInfoBatch,
+  getCommitInfoBatchAsync,
   getDefaultBranch,
   getDefaultBranchAsync,
   getUnresolvedCommentCounts,
@@ -375,15 +377,15 @@ function buildStandaloneBranchRowsSync(
   const defaultBranch = getDefaultBranch(repo);
   const mergedBranches = getMergedStandaloneBranches(repo, allCandidateBranches, defaultBranch);
   const candidateBranches = filterStandaloneBranchesWithoutMerged(allBranches, prs, mergedBranches);
+  if (candidateBranches.length === 0) return [];
+
+  const commitInfoMap = getCommitInfoBatch(repo, candidateBranches, true);
   const rows: BranchWithStatus[] = [];
 
   for (const branch of candidateBranches) {
-    try {
-      const info = getCommitInfo(repo, branch, true);
-      rows.push(toBranchWithStatus(repo, branch, now, info));
-    } catch {
-      // Keep the dashboard responsive when individual branch metadata cannot be loaded.
-    }
+    const info = commitInfoMap.get(branch);
+    if (!info) continue;
+    rows.push(toBranchWithStatus(repo, branch, now, info));
   }
 
   return rows;
@@ -399,16 +401,18 @@ async function buildStandaloneBranchRows(
   const defaultBranch = await getDefaultBranchAsync(repo);
   const mergedBranches = await getMergedStandaloneBranchesAsync(repo, allCandidateBranches, defaultBranch);
   const candidateBranches = filterStandaloneBranchesWithoutMerged(allBranches, prs, mergedBranches);
-  const rows = await Promise.all(candidateBranches.map(async (branch) => {
-    try {
-      const info = await getCommitInfoAsync(repo, branch, true);
-      return toBranchWithStatus(repo, branch, now, info);
-    } catch {
-      return null;
-    }
-  }));
+  if (candidateBranches.length === 0) return [];
 
-  return rows.filter((row): row is BranchWithStatus => row !== null);
+  const commitInfoMap = await getCommitInfoBatchAsync(repo, candidateBranches, true);
+  const rows: BranchWithStatus[] = [];
+
+  for (const branch of candidateBranches) {
+    const info = commitInfoMap.get(branch);
+    if (!info) continue;
+    rows.push(toBranchWithStatus(repo, branch, now, info));
+  }
+
+  return rows;
 }
 
 export function fetchPRsWithStatusSync(options: StatusQueryOptions): StatusRow[] {

--- a/lib/services/status-types.ts
+++ b/lib/services/status-types.ts
@@ -8,7 +8,7 @@ export const STATUS_FIELDS = [
 ];
 
 export const STALE_DAYS = 7;
-export const WATCH_INTERVAL_MS = 30_000;
+export const WATCH_INTERVAL_MS = 60_000;
 export const STATUS_FILTER_SCOPES = ["my-stacks", "all"] as const;
 
 export type StatusFilterScope = typeof STATUS_FILTER_SCOPES[number];

--- a/tests/mock-mode-wiring.test.ts
+++ b/tests/mock-mode-wiring.test.ts
@@ -2,9 +2,9 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import { setApiProvider, resetApiProvider } from "../lib/api-provider.js";
 import { MockApiProvider } from "../lib/mock-api-provider.js";
-import { fetchPRsWithStatus, invalidateStatusCache } from "../lib/services/status-service.js";
+import { fetchPRsWithStatus, filterStandaloneBranches, invalidateStatusCache } from "../lib/services/status-service.js";
 import { markPullRequestReady, retargetPullRequest, enableMergeWhenReady, rerunFailedWorkflowRuns } from "../lib/services/status-actions.js";
-import { getCurrentUser, getCommitInfoBatch, getCommitInfoBatchAsync } from "../lib/gh.js";
+import { getCurrentUser, getCommitInfoBatch, getCommitInfoBatchAsync, listBranches } from "../lib/gh.js";
 
 test("status + actions run through mock provider", async () => {
   const repo = "acme/mock-provider";
@@ -107,33 +107,31 @@ test("getCommitInfoBatchAsync delegates to mock provider", async () => {
   }
 });
 
-test("standalone branches appear via mock provider with batched commit info", async () => {
+test("standalone branch building delegates to mock provider for listBranches and batch commit info", () => {
   const repo = "acme/standalone-test";
   const mock = new MockApiProvider();
-  mock.currentUser = "alice";
-  mock.originRepo = repo;
-  mock.config = { repos: [repo], cursorApiKey: "cur_mock" };
   mock.addRepo(repo, { defaultBranch: "main" });
   mock.addBranch(repo, "cursor/has-pr", { message: "Has PR", authorLogin: "alice", date: new Date("2026-03-10T10:00:00Z") });
   mock.addBranch(repo, "cursor/standalone", { message: "Standalone work", authorLogin: "alice", date: new Date("2026-03-11T10:00:00Z") });
-  mock.addPR(repo, {
-    number: 1,
-    headRefName: "cursor/has-pr",
-    baseRefName: "main",
-    title: "Has PR",
-    isDraft: false,
-    reviewDecision: "APPROVED",
-  });
 
   setApiProvider(mock);
-  invalidateStatusCache();
   try {
-    const rows = await fetchPRsWithStatus({ repos: [repo], scope: "all" });
-    const branchRow = rows.find((row) => row.rowType === "branch" && row.headRefName === "cursor/standalone");
-    assert.ok(branchRow, "standalone branch should appear in status rows");
-    assert.equal(branchRow.title, "Standalone work");
+    const branches = listBranches(repo);
+    assert.ok(branches.includes("cursor/has-pr"));
+    assert.ok(branches.includes("cursor/standalone"));
+
+    const prs = [{ headRefName: "cursor/has-pr", baseRefName: "main", number: 1 }];
+    const standalone = filterStandaloneBranches(branches, prs);
+    assert.deepEqual(standalone, ["cursor/standalone"]);
+
+    const batchInfo = getCommitInfoBatch(repo, standalone, true);
+    assert.equal(batchInfo.size, 1);
+    const info = batchInfo.get("cursor/standalone");
+    assert.ok(info);
+    assert.equal(info.message, "Standalone work");
+    assert.equal(info.authorLogin, "alice");
+    assert.ok(info.date instanceof Date);
   } finally {
     resetApiProvider();
-    invalidateStatusCache();
   }
 });

--- a/tests/mock-mode-wiring.test.ts
+++ b/tests/mock-mode-wiring.test.ts
@@ -4,7 +4,7 @@ import { setApiProvider, resetApiProvider } from "../lib/api-provider.js";
 import { MockApiProvider } from "../lib/mock-api-provider.js";
 import { fetchPRsWithStatus, invalidateStatusCache } from "../lib/services/status-service.js";
 import { markPullRequestReady, retargetPullRequest, enableMergeWhenReady, rerunFailedWorkflowRuns } from "../lib/services/status-actions.js";
-import { getCurrentUser } from "../lib/gh.js";
+import { getCurrentUser, getCommitInfoBatch, getCommitInfoBatchAsync } from "../lib/gh.js";
 
 test("status + actions run through mock provider", async () => {
   const repo = "acme/mock-provider";
@@ -55,6 +55,83 @@ test("status + actions run through mock provider", async () => {
     assert.equal(rerun.total, 1);
     assert.equal(mock.workflowRuns.get(`${repo}:cursor/stack-a`)?.[0].status, "queued");
     assert.equal(mock.workflowRuns.get(`${repo}:cursor/stack-a`)?.[0].conclusion, "");
+  } finally {
+    resetApiProvider();
+    invalidateStatusCache();
+  }
+});
+
+test("getCommitInfoBatch delegates to mock provider", () => {
+  const repo = "acme/batch-test";
+  const mock = new MockApiProvider();
+  mock.addRepo(repo, { defaultBranch: "main" });
+  mock.addBranch(repo, "cursor/feat-a", { message: "Feature A", authorLogin: "alice", date: new Date("2026-03-10T10:00:00Z") });
+  mock.addBranch(repo, "claude/feat-b", { message: "Feature B", authorLogin: "bob", date: new Date("2026-03-11T10:00:00Z") });
+
+  setApiProvider(mock);
+  try {
+    const result = getCommitInfoBatch(repo, ["cursor/feat-a", "claude/feat-b"], true);
+    assert.equal(result.size, 2);
+
+    const infoA = result.get("cursor/feat-a");
+    assert.ok(infoA);
+    assert.equal(infoA.message, "Feature A");
+    assert.equal(infoA.authorLogin, "alice");
+
+    const infoB = result.get("claude/feat-b");
+    assert.ok(infoB);
+    assert.equal(infoB.message, "Feature B");
+    assert.equal(infoB.authorLogin, "bob");
+  } finally {
+    resetApiProvider();
+  }
+});
+
+test("getCommitInfoBatchAsync delegates to mock provider", async () => {
+  const repo = "acme/batch-async-test";
+  const mock = new MockApiProvider();
+  mock.addRepo(repo, { defaultBranch: "main" });
+  mock.addBranch(repo, "cursor/async-a", { message: "Async A", authorLogin: "carol", date: new Date("2026-03-12T10:00:00Z") });
+
+  setApiProvider(mock);
+  try {
+    const result = await getCommitInfoBatchAsync(repo, ["cursor/async-a"], true);
+    assert.equal(result.size, 1);
+
+    const info = result.get("cursor/async-a");
+    assert.ok(info);
+    assert.equal(info.message, "Async A");
+    assert.equal(info.authorLogin, "carol");
+  } finally {
+    resetApiProvider();
+  }
+});
+
+test("standalone branches appear via mock provider with batched commit info", async () => {
+  const repo = "acme/standalone-test";
+  const mock = new MockApiProvider();
+  mock.currentUser = "alice";
+  mock.originRepo = repo;
+  mock.config = { repos: [repo], cursorApiKey: "cur_mock" };
+  mock.addRepo(repo, { defaultBranch: "main" });
+  mock.addBranch(repo, "cursor/has-pr", { message: "Has PR", authorLogin: "alice", date: new Date("2026-03-10T10:00:00Z") });
+  mock.addBranch(repo, "cursor/standalone", { message: "Standalone work", authorLogin: "alice", date: new Date("2026-03-11T10:00:00Z") });
+  mock.addPR(repo, {
+    number: 1,
+    headRefName: "cursor/has-pr",
+    baseRefName: "main",
+    title: "Has PR",
+    isDraft: false,
+    reviewDecision: "APPROVED",
+  });
+
+  setApiProvider(mock);
+  invalidateStatusCache();
+  try {
+    const rows = await fetchPRsWithStatus({ repos: [repo], scope: "all" });
+    const branchRow = rows.find((row) => row.rowType === "branch" && row.headRefName === "cursor/standalone");
+    assert.ok(branchRow, "standalone branch should appear in status rows");
+    assert.equal(branchRow.title, "Standalone work");
   } finally {
     resetApiProvider();
     invalidateStatusCache();

--- a/web/server.ts
+++ b/web/server.ts
@@ -22,9 +22,9 @@ import {
 } from "../lib/services/status-actions.js";
 import {
   STATUS_FILTER_SCOPES,
-  WATCH_INTERVAL_MS,
   type StatusFilterScope,
 } from "../lib/services/status-types.js";
+import { getWatchIntervalMs } from "../lib/config.js";
 import { findLatestAgentByPrUrl, getArtifactDownloadUrl, listAgentArtifacts, listAgentsByPrUrl } from "../lib/cursor-api.js";
 import { sendReplyViaCursorApi } from "../lib/cursor-replies.js";
 import { loadTemplates, resolveTemplatesPath } from "../lib/templates.js";
@@ -229,7 +229,7 @@ async function handleApi(req: IncomingMessage, url: URL, res: ServerResponse): P
     sendJson(res, 200, {
       repos,
       scope,
-      pollIntervalMs: WATCH_INTERVAL_MS,
+      pollIntervalMs: getWatchIntervalMs(),
       rows,
       cursorApiConfigured: Boolean(loadConfig()?.cursorApiKey?.trim()),
     });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
- Increase default poll interval from 30s to 60s, add configurable `pollIntervalMs` in .copserc
- Batch standalone branch commit info into single GraphQL queries instead of per-branch REST calls
- Batch commit info in create-prs and rerun-failed commands similarly
- Reduce workflow run fetch limit from 100 to 25 (only need latest runs for CI status)
- Reduce failed run fetch limit from 50 to 20
- Reduce coauthor scan commit count from 100 to 30
- Add provider delegation to `getCommitInfoBatch`/`getCommitInfoBatchAsync` for mock mode compatibility
- Add mock provider integration tests for batch commit info and standalone branch flows

Rebased over main (including PR #40 hide-merged-standalone-branches and PR #41 mockable-api-system-testing). All 36 tests pass.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ccc058e8-cd23-4a89-b5b3-7f8c9663ead9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ccc058e8-cd23-4a89-b5b3-7f8c9663ead9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

