### PR TITLE
Fix flaky mock-provider status test by bypassing stale disk cache

### DIFF
--- a/lib/services/status-service.ts
+++ b/lib/services/status-service.ts
@@ -535,6 +535,12 @@ function startStatusRefresh(key: string, options: StatusQueryOptions): Promise<S
 }
 
 export async function fetchPRsWithStatus(options: StatusQueryOptions): Promise<StatusRow[]> {
+  // Provider-backed calls (tests/mock mode) should always reflect current in-memory state.
+  // Returning stale disk cache across provider swaps can make tests flaky.
+  if (getApiProvider()) {
+    return fetchPRsWithStatusUncached(options);
+  }
+
   const key = cacheKey(options);
   let cached = statusCache.get(key) ?? null;
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- bypass persistent status caching when a custom API provider is active
- ensure provider-backed flows (including `MockApiProvider` tests) always read fresh in-memory state
- prevent stale on-disk cache entries from being returned across provider swaps in test runs

## Validation
- `npm test` passes (`39/39`)
- `node --test "dist/tests/mock-mode-wiring.test.js"` passes (`4/4`)
- deterministic repro now shows correct behavior after provider swap (`first_ci none`, `second_ci fail`)
- repeated reliability check: 10 consecutive `npm test` runs all passed
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-37fa5eaa-a206-48f5-a936-c79c5a3e111c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-37fa5eaa-a206-48f5-a936-c79c5a3e111c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

