### PR TITLE
Consolidate ANSI formatting constants into lib/format.ts

### DIFF
--- a/commands/approval.ts
+++ b/commands/approval.ts
@@ -18,6 +18,7 @@
 
 import { initializeRuntime } from "../lib/runtime-init.js";
 import { getOriginRepo } from "../lib/utils.js";
+import { ANSI } from "../lib/format.js";
 import type { ExecError } from "../lib/types.js";
 import {
   REPO_PATTERN, validateRepo, gh, formatGhError, listOpenPRs,
@@ -174,6 +175,6 @@ Examples:
 try {
   main();
 } catch (e: unknown) {
-  console.error(`\x1b[31merror\x1b[0m ${(e as Error).message}`);
+  console.error(`${ANSI.red}error${ANSI.reset} ${(e as Error).message}`);
   process.exit(1);
 }

--- a/commands/create-issue.ts
+++ b/commands/create-issue.ts
@@ -34,17 +34,9 @@ import { REPO_PATTERN, validateRepo, validateAgent } from "../lib/gh.js";
 import { getOriginRepo } from "../lib/utils.js";
 import { loadConfig } from "../lib/config.js";
 import { launchAgentForPrUrl, launchAgentForRepository } from "../lib/cursor-api.js";
+import { ANSI } from "../lib/format.js";
 
 initializeRuntime();
-
-const ANSI = {
-  reset: "\x1b[0m",
-  dim: "\x1b[2m",
-  bold: "\x1b[1m",
-  cyan: "\x1b[36m",
-  green: "\x1b[32m",
-  red: "\x1b[31m",
-};
 
 const DEFAULT_ISSUE_TEMPLATE_PATHS = [
   ".github/issue_template.md",

--- a/commands/init.ts
+++ b/commands/init.ts
@@ -20,18 +20,9 @@ import { homedir } from "os";
 import { initializeRuntime } from "../lib/runtime-init.js";
 import { REPO_PATTERN } from "../lib/gh.js";
 import { getOriginRepo } from "../lib/utils.js";
+import { ANSI } from "../lib/format.js";
 
 initializeRuntime();
-
-const ANSI = {
-  reset: "\x1b[0m",
-  dim: "\x1b[2m",
-  bold: "\x1b[1m",
-  cyan: "\x1b[36m",
-  green: "\x1b[32m",
-  red: "\x1b[31m",
-  yellow: "\x1b[33m",
-};
 
 const CONFIG_FILENAME = ".copserc";
 const GITHUB_DIR = ".github";

--- a/commands/pr-comments.ts
+++ b/commands/pr-comments.ts
@@ -10,7 +10,7 @@ import * as readline from "node:readline/promises";
 import { stdin, stdout } from "node:process";
 import { initializeRuntime } from "../lib/runtime-init.js";
 import { getOriginRepo, isBotComment } from "../lib/utils.js";
-import { formatCommentBody } from "../lib/format.js";
+import { ANSI, formatCommentBody } from "../lib/format.js";
 import type { PR, PRReviewComment } from "../lib/types.js";
 import {
   REPO_PATTERN,
@@ -36,16 +36,6 @@ import {
 import type { ExecError } from "../lib/types.js";
 
 initializeRuntime();
-
-const ANSI = {
-  reset: "\x1b[0m",
-  dim: "\x1b[2m",
-  bold: "\x1b[1m",
-  underline: "\x1b[4m",
-  cyan: "\x1b[36m",
-  yellow: "\x1b[33m",
-  red: "\x1b[31m",
-};
 
 function hyperlink(url: string, text: string): string {
   return `\x1b]8;;${url}\x1b\\${text}\x1b]8;;\x1b\\`;

--- a/commands/status.ts
+++ b/commands/status.ts
@@ -23,7 +23,7 @@ import {
 } from "../lib/gh.js";
 import type { PRReviewComment, PRChangedFile } from "../lib/types.js";
 import { getUserForDisplay, buildFetchMessage } from "../lib/filters.js";
-import { formatCommentBody, wrapAnsiText } from "../lib/format.js";
+import { ANSI, formatBytes, formatCommentBody, wrapAnsiText } from "../lib/format.js";
 import { getConfiguredRepos, loadConfig } from "../lib/config.js";
 import { getOriginRepo } from "../lib/utils.js";
 import { parseStandardFlags, parseTemplatesOption } from "../lib/args.js";
@@ -51,7 +51,6 @@ import {
   needsScaffold,
   resolveTemplatesPath,
 } from "../lib/templates.js";
-import { formatBytes } from "../lib/format.js";
 
 initializeRuntime();
 
@@ -93,15 +92,6 @@ function matchesSearch(pr: PRWithStatus, query: string): boolean {
   return searchable.some(f => f.toLowerCase().includes(q));
 }
 
-
-const ANSI = {
-  reset: "\x1b[0m",
-  red: "\x1b[31m",
-  amber: "\x1b[33m",
-  green: "\x1b[32m",
-  dim: "\x1b[2m",
-  bold: "\x1b[1m",
-};
 
 function hyperlink(url: string, text: string): string {
   if (!process.stdout.isTTY) return text;

--- a/lib/format.ts
+++ b/lib/format.ts
@@ -1,12 +1,15 @@
 import { hyperlink } from "./utils.js";
 
-const ANSI = {
+export const ANSI = {
   reset: "\x1b[0m",
   dim: "\x1b[2m",
   bold: "\x1b[1m",
+  underline: "\x1b[4m",
   cyan: "\x1b[36m",
   yellow: "\x1b[33m",
+  amber: "\x1b[33m",
   red: "\x1b[31m",
+  green: "\x1b[32m",
 };
 
 const BYTES_STEP = 1024;


### PR DESCRIPTION
Move duplicate ANSI escape code definitions from status.ts, create-issue.ts,
init.ts, pr-comments.ts, and approval.ts into a single exported ANSI object
in lib/format.ts. This eliminates five redundant constant blocks and provides
a unified set including all needed codes (reset, dim, bold, underline, cyan,
yellow, amber, red, green).

https://claude.ai/code/session_01T3vfAFjYXYeZKydn41oxcw